### PR TITLE
Add site CLIs for AWS, GCP, and Azure documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Works on any mostly-static site with no per-site setup: news sites, blogs, docum
 | Stack Overflow | stackoverflow.com (via Atom feeds) | `question <id>`, `tag <name>`, `user <id>`, `recent` |
 | Yahoo Finance | finance.yahoo.com | `quote <symbol>`, `news <symbol>`, `history <symbol>`, `lookup <query>`, `markets`, `gainers`, `losers`, `trending` |
 | YouTube | youtube.com | `video <id>`, `channel <name>` |
-| AWS docs | docs.aws.amazon.com | `guide <service> <page>`, `page <service> <guide> <page>`, `cli <command>` |
-| Google Cloud docs | cloud.google.com (via docs.cloud.google.com) | `docs <product>`, `page <product> <page>`, `gcloud <command>` |
-| Microsoft Learn | learn.microsoft.com | `azure <page>`, `doc <path>`, `cli <command>` |
+| AWS docs | docs.aws.amazon.com (search via DuckDuckGo) | `guide <service> <page>`, `page <service> <guide> <page>`, `cli <command>`, `search <query>` |
+| Google Cloud docs | cloud.google.com (via docs.cloud.google.com, search via DuckDuckGo) | `docs <product>`, `page <product> <page>`, `gcloud <command>`, `search <query>` |
+| Microsoft Learn | learn.microsoft.com (search via its RSS API) | `azure <page>`, `doc <path>`, `cli <command>`, `search <query>` |
 
-A few of these (X, Stack Overflow, YouTube) read pages that look login-gated or JS-only from the outside, by finding the server-rendered HTML, feed, or inline data the page already ships without a login. Not supported yet: pages that only render with JavaScript, sites behind logins, and sites with hard bot challenges that expose no feed.
+A few of these (X, Stack Overflow, YouTube, Microsoft Learn search) read pages that look login-gated or JS-only from the outside, by finding the server-rendered HTML, feed, or inline data the page already ships without a login. AWS and Google Cloud render docs search purely client-side with no feed, so their `search` goes through DuckDuckGo with a baked-in `site:` filter instead. Not supported yet: pages that only render with JavaScript, sites behind logins, and sites with hard bot challenges that expose no feed.
 
 Want a website on that list? Open a pull request, or an issue naming the site — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Works on any mostly-static site with no per-site setup: news sites, blogs, docum
 | Stack Overflow | stackoverflow.com (via Atom feeds) | `question <id>`, `tag <name>`, `user <id>`, `recent` |
 | Yahoo Finance | finance.yahoo.com | `quote <symbol>`, `news <symbol>`, `history <symbol>`, `lookup <query>`, `markets`, `gainers`, `losers`, `trending` |
 | YouTube | youtube.com | `video <id>`, `channel <name>` |
+| AWS docs | docs.aws.amazon.com | `guide <service> <page>`, `page <service> <guide> <page>`, `cli <command>` |
+| Google Cloud docs | cloud.google.com (via docs.cloud.google.com) | `docs <product>`, `page <product> <page>`, `gcloud <command>` |
+| Microsoft Learn | learn.microsoft.com | `azure <page>`, `doc <path>`, `cli <command>` |
 
 A few of these (X, Stack Overflow, YouTube) read pages that look login-gated or JS-only from the outside, by finding the server-rendered HTML, feed, or inline data the page already ships without a login. Not supported yet: pages that only render with JavaScript, sites behind logins, and sites with hard bot challenges that expose no feed.
 

--- a/clis/cloud.google.com.json
+++ b/clis/cloud.google.com.json
@@ -1,0 +1,8 @@
+{
+  "domain": "cloud.google.com",
+  "commands": {
+    "docs": { "open": "https://docs.cloud.google.com/{product}/docs", "args": ["product"] },
+    "page": { "open": "https://docs.cloud.google.com/{product}/docs/{page}", "args": ["product", "page"] },
+    "gcloud": { "open": "https://docs.cloud.google.com/sdk/gcloud/reference/{command}", "args": ["command"] }
+  }
+}

--- a/clis/cloud.google.com.json
+++ b/clis/cloud.google.com.json
@@ -3,6 +3,7 @@
   "commands": {
     "docs": { "open": "https://docs.cloud.google.com/{product}/docs", "args": ["product"] },
     "page": { "open": "https://docs.cloud.google.com/{product}/docs/{page}", "args": ["product", "page"] },
-    "gcloud": { "open": "https://docs.cloud.google.com/sdk/gcloud/reference/{command}", "args": ["command"] }
+    "gcloud": { "open": "https://docs.cloud.google.com/sdk/gcloud/reference/{command}", "args": ["command"] },
+    "search": { "open": "https://html.duckduckgo.com/html/?q=site%3Acloud.google.com+{query}", "args": ["query"] }
   }
 }

--- a/clis/docs.aws.amazon.com.json
+++ b/clis/docs.aws.amazon.com.json
@@ -3,6 +3,7 @@
   "commands": {
     "guide": { "open": "https://docs.aws.amazon.com/{service}/latest/userguide/{page}.html", "args": ["service", "page"] },
     "page": { "open": "https://docs.aws.amazon.com/{service}/latest/{guide}/{page}.html", "args": ["service", "guide", "page"] },
-    "cli": { "open": "https://docs.aws.amazon.com/cli/latest/reference/{command}/", "args": ["command"] }
+    "cli": { "open": "https://docs.aws.amazon.com/cli/latest/reference/{command}/", "args": ["command"] },
+    "search": { "open": "https://html.duckduckgo.com/html/?q=site%3Adocs.aws.amazon.com+{query}", "args": ["query"] }
   }
 }

--- a/clis/docs.aws.amazon.com.json
+++ b/clis/docs.aws.amazon.com.json
@@ -1,0 +1,8 @@
+{
+  "domain": "docs.aws.amazon.com",
+  "commands": {
+    "guide": { "open": "https://docs.aws.amazon.com/{service}/latest/userguide/{page}.html", "args": ["service", "page"] },
+    "page": { "open": "https://docs.aws.amazon.com/{service}/latest/{guide}/{page}.html", "args": ["service", "guide", "page"] },
+    "cli": { "open": "https://docs.aws.amazon.com/cli/latest/reference/{command}/", "args": ["command"] }
+  }
+}

--- a/clis/learn.microsoft.com.json
+++ b/clis/learn.microsoft.com.json
@@ -1,0 +1,8 @@
+{
+  "domain": "learn.microsoft.com",
+  "commands": {
+    "azure": { "open": "https://learn.microsoft.com/en-us/azure/{page}", "args": ["page"] },
+    "doc": { "open": "https://learn.microsoft.com/en-us/{path}", "args": ["path"] },
+    "cli": { "open": "https://learn.microsoft.com/en-us/cli/azure/{command}", "args": ["command"] }
+  }
+}

--- a/clis/learn.microsoft.com.json
+++ b/clis/learn.microsoft.com.json
@@ -3,6 +3,7 @@
   "commands": {
     "azure": { "open": "https://learn.microsoft.com/en-us/azure/{page}", "args": ["page"] },
     "doc": { "open": "https://learn.microsoft.com/en-us/{path}", "args": ["path"] },
-    "cli": { "open": "https://learn.microsoft.com/en-us/cli/azure/{command}", "args": ["command"] }
+    "cli": { "open": "https://learn.microsoft.com/en-us/cli/azure/{command}", "args": ["command"] },
+    "search": { "open": "https://learn.microsoft.com/api/search/rss?search={query}&locale=en-us", "args": ["query"] }
   }
 }


### PR DESCRIPTION
## What and why

Adds three per-domain configs under `clis/` for the major cloud providers' documentation sites, plus README table rows. Closes #11.

- `docs.aws.amazon.com`: `guide <service> <page>` (userguide pages), `page <service> <guide> <page>` (other guide directories like `dg` or `APIReference`), `cli <command>` (AWS CLI reference), `search <query>`
- `cloud.google.com`: `docs <product>`, `page <product> <page>`, `gcloud <command>`, `search <query>`. URLs point at `docs.cloud.google.com` because `cloud.google.com` 301s every docs path there; skipping the redirect saves a round trip, same trick as reddit.com going via old.reddit.com.
- `learn.microsoft.com`: `azure <page>`, `doc <path>` (non-Azure Learn content), `cli <command>` (Azure CLI reference), `search <query>`. Templates pin `/en-us/` so output does not depend on the client locale.

### Search

All three providers render their own docs search client-side, so distilling the search page yields only nav chrome. What each `search` command does instead, in order of preference found:

- Microsoft Learn has a public RSS search endpoint (`/api/search/rss?search=...`) that serves real results as a feed, and the engine already renders feeds (same route as Stack Overflow). Verified live: titled, linked results for "app service deploy".
- AWS and Google Cloud expose search only as JSON, which the engine cannot render until #3 lands, so their `search` goes through DuckDuckGo HTML with a baked-in `site:` filter, the same endpoint the duckduckgo.com CLI already relies on. Verified live for `site:docs.aws.amazon.com lambda timeout` (real doc pages with snippets). Caveat noted in the README: DuckDuckGo answers rapid-fire automated use with a challenge page. Bing was tried first for this job and rejected: it silently drops the `site:` operator on some queries, returning unrelated results. Once #3 lands these two can switch to the providers' own JSON search APIs.

### Verification

All eight article URL templates plus the two search routes were exercised against the live sites with `fetchPage` + `distill`: HTTP 200, real titles, 56 to 4126 content blocks each.

## Checklist

- [x] `--stats` before/after on a fixture, if this changes what a page renders (n/a, no renderer changes)
- [x] No new dependency, or a one-line justification here if there is one
- [x] New behavior has a fixture in `tests/pages/` and a test in `tests/` (n/a, config only; live coverage comes from the canary)
- [x] `npm test` passes
- [x] `npm run typecheck` passes (n/a, no such script on main)
- [x] If this touches `clis/*.json`: `npm run lint:clis` passes and the file is still under 50 lines (all three are 10 lines)