### PR TITLE
feat: route outbound fetches through HTTP_PROXY, HTTPS_PROXY, and NO_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you are an LLM reading this repository, [llms.txt](llms.txt) is the short ver
 npm install -g @only-cli/oc
 ```
 
-Requires Node 20+. Requests impersonate Chrome via [impers](https://github.com/lexiforest/impers); falls back to native fetch if impers is unavailable.
+Requires Node 20+. Requests impersonate Chrome via [impers](https://github.com/lexiforest/impers); falls back to native fetch if impers is unavailable. Outbound fetches honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` when set.
 
 ### Agent skill
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -8,7 +8,10 @@
  */
 
 import dns from 'node:dns/promises';
+import http from 'node:http';
+import https from 'node:https';
 import net from 'node:net';
+import tls from 'node:tls';
 
 // The fetch fallback can't fake a TLS fingerprint like impers does, but it
 // should at least send the same Chrome identity in its headers.
@@ -146,6 +149,214 @@ async function assertSafeTarget(urlStr) {
   }
 }
 
+function envFirst(env, ...names) {
+  for (const name of names) {
+    const value = env[name];
+    if (value) return value;
+  }
+}
+
+function normalizeProxy(value) {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  if (!trimmed) return null;
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+}
+
+// Split host[:port], including [IPv6]:port. A trailing :digits is a port;
+// anything else stays part of the hostname so NO_PROXY=example.com matches.
+function splitHostPort(entry) {
+  if (entry.startsWith('[')) {
+    const end = entry.indexOf(']');
+    if (end === -1) return { host: entry, port: '' };
+    const rest = entry.slice(end + 1);
+    return { host: entry.slice(1, end), port: rest.startsWith(':') ? rest.slice(1) : '' };
+  }
+  const colon = entry.lastIndexOf(':');
+  if (colon !== -1 && /^\d+$/.test(entry.slice(colon + 1))) {
+    return { host: entry.slice(0, colon), port: entry.slice(colon + 1) };
+  }
+  return { host: entry, port: '' };
+}
+
+function bypassesProxy(target, noProxy) {
+  const list = noProxy.trim();
+  if (!list) return false;
+  const hostname = target.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  const port = target.port || (target.protocol === 'https:' ? '443' : '80');
+  for (let entry of list.split(',')) {
+    entry = entry.trim();
+    if (!entry) continue;
+    if (entry === '*') return true;
+    const { host: rawHost, port: entryPort } = splitHostPort(entry);
+    if (entryPort && entryPort !== port) continue;
+    const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '').replace(/^\./, '');
+    if (!host) continue;
+    if (hostname === host || hostname.endsWith(`.${host}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Pick a proxy for this URL from HTTP_PROXY / HTTPS_PROXY / NO_PROXY (and
+ * their lowercase forms). The proxy host is not run through assertSafeTarget:
+ * corporate proxies live on loopback or RFC 1918 addresses, and they are not
+ * the page being fetched. Redirect hops still go through that check.
+ * @param {string} url
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string | null} proxy URL, or null to connect directly
+ */
+export function resolveProxy(url, env = process.env) {
+  const target = new URL(url);
+  if (bypassesProxy(target, envFirst(env, 'NO_PROXY', 'no_proxy') ?? '')) return null;
+  const httpsProxy = envFirst(env, 'HTTPS_PROXY', 'https_proxy');
+  const httpProxy = envFirst(env, 'HTTP_PROXY', 'http_proxy');
+  const chosen = target.protocol === 'https:' ? (httpsProxy || httpProxy) : httpProxy;
+  return normalizeProxy(chosen);
+}
+
+function proxyAuthHeader(proxy) {
+  if (!proxy.username) return undefined;
+  const token = Buffer.from(`${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`).toString('base64');
+  return `Basic ${token}`;
+}
+
+function authority(target) {
+  const host = net.isIP(target.hostname) === 6 ? `[${target.hostname}]` : target.hostname;
+  const port = target.port || (target.protocol === 'https:' ? '443' : '80');
+  return `${host}:${port}`;
+}
+
+function wrapNodeResponse(res, url) {
+  const headers = {
+    get(name) {
+      const v = res.headers[name.toLowerCase()];
+      if (v == null) return null;
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const text = () => new Promise((resolve, reject) => {
+    const chunks = [];
+    res.on('data', (c) => chunks.push(c));
+    res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    res.on('error', reject);
+  });
+  const status = res.statusCode ?? 0;
+  return {
+    status,
+    statusText: res.statusMessage || '',
+    headers,
+    ok: status >= 200 && status < 300,
+    url,
+    text,
+  };
+}
+
+function proxyTransport(proxy) {
+  return proxy.protocol === 'https:' ? https : http;
+}
+
+function proxyPort(proxy) {
+  return Number(proxy.port) || (proxy.protocol === 'https:' ? 443 : 80);
+}
+
+function httpViaProxy(target, proxy, headers) {
+  const auth = proxyAuthHeader(proxy);
+  return new Promise((resolve, reject) => {
+    const req = proxyTransport(proxy).request({
+      hostname: proxy.hostname,
+      port: proxyPort(proxy),
+      method: 'GET',
+      path: target.href,
+      headers: {
+        ...headers,
+        host: target.host,
+        ...(auth && { 'proxy-authorization': auth }),
+      },
+    }, (res) => resolve(wrapNodeResponse(res, target.href)));
+    req.on('error', (err) => reject(new Error(`proxy failed: ${err.message} for ${target.href}`)));
+    req.end();
+  });
+}
+
+function httpsViaConnect(target, proxy, headers, tlsOpts = {}) {
+  const dest = authority(target);
+  const auth = proxyAuthHeader(proxy);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const fail = (err) => {
+      if (settled) return;
+      settled = true;
+      req.destroy();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const req = proxyTransport(proxy).request({
+      hostname: proxy.hostname,
+      port: proxyPort(proxy),
+      method: 'CONNECT',
+      path: dest,
+      headers: {
+        host: dest,
+        ...(auth && { 'proxy-authorization': auth }),
+      },
+    });
+    req.on('connect', (res, socket, head) => {
+      if (res.statusCode !== 200) {
+        socket.destroy();
+        fail(new Error(`proxy CONNECT failed: ${res.statusCode} for ${target.href}`));
+        return;
+      }
+      if (head.length) socket.unshift(head);
+      // tls.connect already opened the tunnel. https.request would wrap TLS
+      // again, and the origin would see a second ClientHello as garbage.
+      // SNI is a hostname; an IP literal is only used for the cert check.
+      const hostname = target.hostname;
+      const tlsSocket = tls.connect({
+        socket,
+        host: hostname,
+        ...(net.isIP(hostname) ? {} : { servername: hostname }),
+        ...tlsOpts,
+      }, () => {
+        const tunneled = http.request({
+          createConnection: () => tlsSocket,
+          path: `${target.pathname}${target.search}`,
+          method: 'GET',
+          headers: { ...headers, host: target.host },
+        }, (httpsRes) => {
+          if (settled) return;
+          settled = true;
+          resolve(wrapNodeResponse(httpsRes, target.href));
+        });
+        tunneled.on('error', (err) => fail(new Error(`proxy failed: ${err.message || err.code} for ${target.href}`)));
+        tunneled.end();
+      });
+      tlsSocket.on('error', (err) => fail(new Error(`proxy failed: ${err.message || err.code} for ${target.href}`)));
+    });
+    req.on('error', (err) => fail(new Error(`proxy failed: ${err.message || err.code} for ${target.href}`)));
+    req.end();
+  });
+}
+
+/**
+ * One GET through an HTTP(S) proxy. HTTP targets use the absolute-URI form;
+ * HTTPS targets open a CONNECT tunnel first. Redirects are not followed:
+ * followRedirects owns that so each hop still goes through assertSafeTarget.
+ * @param {string} url
+ * @param {string} proxy
+ * @param {Record<string, string>} [headers]
+ * @param {import('node:tls').ConnectionOptions} [tlsOpts]
+ */
+export function proxyGet(url, proxy, headers = {}, tlsOpts = {}) {
+  const target = new URL(url);
+  const proxyUrl = new URL(proxy);
+  if (!/^https?:$/.test(proxyUrl.protocol)) {
+    throw new Error(`unsupported proxy protocol (${proxyUrl.protocol.slice(0, -1)}), oc honors HTTP and HTTPS proxies`);
+  }
+  return target.protocol === 'https:'
+    ? httpsViaConnect(target, proxyUrl, headers, tlsOpts)
+    : httpViaProxy(target, proxyUrl, headers);
+}
+
 /**
  * Fetch a page.
  * @param {string} url - with or without a scheme, https is assumed
@@ -190,10 +401,19 @@ export async function followRedirects(get, start) {
   }
 }
 
+const FETCH_HEADERS = {
+  'user-agent': UA,
+  accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+  'accept-language': 'en-US,en;q=0.9',
+};
+
 async function viaImpers(impers, target) {
   // Some sites (Reddit) 403 the chrome fingerprint but accept firefox, so a
   // blocked first attempt gets one cheap retry with a second identity.
-  const asking = (impersonate) => (url) => impers.get(url, { impersonate, allowRedirects: false });
+  const asking = (impersonate) => (url) => {
+    const proxy = resolveProxy(url);
+    return impers.get(url, { impersonate, allowRedirects: false, ...(proxy && { proxy }) });
+  };
   let via = 'impers:chrome';
   let { res } = await followRedirects(asking('chrome'), target);
   let status = res.status ?? res.statusCode ?? 0;
@@ -209,14 +429,12 @@ async function viaImpers(impers, target) {
 }
 
 async function viaFetch(target) {
-  const { res, url: current } = await followRedirects((url) => fetch(url, {
-    redirect: 'manual',
-    headers: {
-      'user-agent': UA,
-      accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      'accept-language': 'en-US,en;q=0.9',
-    },
-  }), target);
+  const { res, url: current } = await followRedirects((url) => {
+    const proxy = resolveProxy(url);
+    return proxy
+      ? proxyGet(url, proxy, FETCH_HEADERS)
+      : fetch(url, { redirect: 'manual', headers: FETCH_HEADERS });
+  }, target);
   if (!res.ok) {
     throw new Error(`fetch failed: ${res.status} ${res.statusText} for ${current}`);
   }

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -26,6 +26,8 @@ const loadImpers = () => {
 
 const BLOCKED_MESSAGE = 'blocked: private or internal URL';
 const MAX_REDIRECTS = 20;
+// Match undici's default so proxy transport does not hang indefinitely.
+const PROXY_TIMEOUT_MS = 300_000;
 
 // What oc can turn into text: any text/* type, plus the application/* types
 // that are really text (json, xml, and the +json / +xml families a feed or an
@@ -142,7 +144,12 @@ async function assertSafeTarget(urlStr) {
     return;
   }
   if (hostname === 'localhost') throw new Error(BLOCKED_MESSAGE);
-  const addresses = await dns.lookup(hostname, { all: true }).catch(() => []);
+  const addresses = await dns.lookup(hostname, { all: true }).catch(() => {
+    // With a proxy the client never resolves the target; the proxy does, often
+    // on corporate DNS where internal names are NXDOMAIN locally. Fail closed.
+    if (resolveProxy(urlStr)) throw new Error(BLOCKED_MESSAGE);
+    return [];
+  });
   for (const { address, family } of addresses) {
     if (family === 4 && isBlockedIPv4(address)) throw new Error(BLOCKED_MESSAGE);
     if (family === 6 && isBlockedIPv6(address)) throw new Error(BLOCKED_MESSAGE);
@@ -163,8 +170,15 @@ function normalizeProxy(value) {
   return /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
 }
 
-// Split host[:port], including [IPv6]:port. A trailing :digits is a port;
-// anything else stays part of the hostname so NO_PROXY=example.com matches.
+function assertHttpProxyProtocol(proxyUrl) {
+  if (!/^https?:$/.test(proxyUrl.protocol)) {
+    throw new Error(`unsupported proxy protocol (${proxyUrl.protocol.slice(0, -1)}), oc honors HTTP and HTTPS proxies`);
+  }
+}
+
+// Split host[:port], including [IPv6]:port. Unbracketed IPv6 literals never
+// carry a port suffix (use [addr]:port); a trailing :digits on ::1 is part of
+// the address, not a port.
 function splitHostPort(entry) {
   if (entry.startsWith('[')) {
     const end = entry.indexOf(']');
@@ -172,11 +186,44 @@ function splitHostPort(entry) {
     const rest = entry.slice(end + 1);
     return { host: entry.slice(1, end), port: rest.startsWith(':') ? rest.slice(1) : '' };
   }
+  if (net.isIP(entry) === 6) return { host: entry, port: '' };
   const colon = entry.lastIndexOf(':');
   if (colon !== -1 && /^\d+$/.test(entry.slice(colon + 1))) {
-    return { host: entry.slice(0, colon), port: entry.slice(colon + 1) };
+    const host = entry.slice(0, colon);
+    if (net.isIP(host) === 6) return { host: entry, port: '' };
+    return { host, port: entry.slice(colon + 1) };
   }
   return { host: entry, port: '' };
+}
+
+function ipv4InCidr(ip, base, bits) {
+  const mask = bits === 0 ? 0 : (0xffffffff << (32 - bits)) >>> 0;
+  return (ipv4ToInt(ip) & mask) === (ipv4ToInt(base) & mask);
+}
+
+function ipv6InCidr(ip, base, bits) {
+  const g = expandIPv6(ip);
+  const b = expandIPv6(base);
+  if (!g || !b) return false;
+  let remaining = bits;
+  for (let i = 0; i < 8 && remaining > 0; i++) {
+    if (remaining >= 16) {
+      if (g[i] !== b[i]) return false;
+      remaining -= 16;
+    } else {
+      const mask = (0xffff << (16 - remaining)) & 0xffff;
+      if ((g[i] & mask) !== (b[i] & mask)) return false;
+      remaining = 0;
+    }
+  }
+  return true;
+}
+
+function ipInCidr(ip, base, bits) {
+  const family = net.isIP(ip);
+  if (family === 4) return ipv4InCidr(ip, base, bits);
+  if (family === 6) return ipv6InCidr(ip, base, bits);
+  return false;
 }
 
 function bypassesProxy(target, noProxy) {
@@ -190,8 +237,23 @@ function bypassesProxy(target, noProxy) {
     if (entry === '*') return true;
     const { host: rawHost, port: entryPort } = splitHostPort(entry);
     if (entryPort && entryPort !== port) continue;
-    const host = rawHost.toLowerCase().replace(/^\[|\]$/g, '').replace(/^\./, '');
+    let pattern = rawHost.toLowerCase().replace(/^\[|\]$/g, '');
+    const wildcard = pattern.startsWith('*.');
+    if (wildcard) pattern = pattern.slice(2);
+    const slash = pattern.indexOf('/');
+    if (slash !== -1 && net.isIP(pattern.slice(0, slash))) {
+      const bits = Number(pattern.slice(slash + 1));
+      if (Number.isInteger(bits) && net.isIP(hostname) && ipInCidr(hostname, pattern.slice(0, slash), bits)) {
+        return true;
+      }
+      continue;
+    }
+    const host = pattern.replace(/^\./, '');
     if (!host) continue;
+    if (wildcard) {
+      if (hostname.endsWith(`.${host}`)) return true;
+      continue;
+    }
     if (hostname === host || hostname.endsWith(`.${host}`)) return true;
   }
   return false;
@@ -212,12 +274,23 @@ export function resolveProxy(url, env = process.env) {
   const httpsProxy = envFirst(env, 'HTTPS_PROXY', 'https_proxy');
   const httpProxy = envFirst(env, 'HTTP_PROXY', 'http_proxy');
   const chosen = target.protocol === 'https:' ? (httpsProxy || httpProxy) : httpProxy;
-  return normalizeProxy(chosen);
+  const normalized = normalizeProxy(chosen);
+  if (!normalized) return null;
+  assertHttpProxyProtocol(new URL(normalized));
+  return normalized;
+}
+
+function decodeCredential(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function proxyAuthHeader(proxy) {
   if (!proxy.username) return undefined;
-  const token = Buffer.from(`${decodeURIComponent(proxy.username)}:${decodeURIComponent(proxy.password)}`).toString('base64');
+  const token = Buffer.from(`${decodeCredential(proxy.username)}:${decodeCredential(proxy.password)}`).toString('base64');
   return `Basic ${token}`;
 }
 
@@ -260,6 +333,17 @@ function proxyPort(proxy) {
   return Number(proxy.port) || (proxy.protocol === 'https:' ? 443 : 80);
 }
 
+function armRequestTimeout(req, reject, label) {
+  req.setTimeout(PROXY_TIMEOUT_MS, () => {
+    req.destroy();
+    reject(new Error(`proxy timed out after ${PROXY_TIMEOUT_MS / 1000}s for ${label}`));
+  });
+}
+
+function pickTlsCa(tlsOpts) {
+  return tlsOpts.ca != null ? { ca: tlsOpts.ca } : {};
+}
+
 function httpViaProxy(target, proxy, headers) {
   const auth = proxyAuthHeader(proxy);
   return new Promise((resolve, reject) => {
@@ -267,13 +351,14 @@ function httpViaProxy(target, proxy, headers) {
       hostname: proxy.hostname,
       port: proxyPort(proxy),
       method: 'GET',
-      path: target.href,
+      path: `${target.protocol}//${target.host}${target.pathname}${target.search}`,
       headers: {
         ...headers,
         host: target.host,
         ...(auth && { 'proxy-authorization': auth }),
       },
     }, (res) => resolve(wrapNodeResponse(res, target.href)));
+    armRequestTimeout(req, reject, target.href);
     req.on('error', (err) => reject(new Error(`proxy failed: ${err.message} for ${target.href}`)));
     req.end();
   });
@@ -300,6 +385,7 @@ function httpsViaConnect(target, proxy, headers, tlsOpts = {}) {
         ...(auth && { 'proxy-authorization': auth }),
       },
     });
+    armRequestTimeout(req, fail, target.href);
     req.on('connect', (res, socket, head) => {
       if (res.statusCode !== 200) {
         socket.destroy();
@@ -315,7 +401,7 @@ function httpsViaConnect(target, proxy, headers, tlsOpts = {}) {
         socket,
         host: hostname,
         ...(net.isIP(hostname) ? {} : { servername: hostname }),
-        ...tlsOpts,
+        ...pickTlsCa(tlsOpts),
       }, () => {
         const tunneled = http.request({
           createConnection: () => tlsSocket,
@@ -327,6 +413,7 @@ function httpsViaConnect(target, proxy, headers, tlsOpts = {}) {
           settled = true;
           resolve(wrapNodeResponse(httpsRes, target.href));
         });
+        armRequestTimeout(tunneled, fail, target.href);
         tunneled.on('error', (err) => fail(new Error(`proxy failed: ${err.message || err.code} for ${target.href}`)));
         tunneled.end();
       });
@@ -349,9 +436,7 @@ function httpsViaConnect(target, proxy, headers, tlsOpts = {}) {
 export function proxyGet(url, proxy, headers = {}, tlsOpts = {}) {
   const target = new URL(url);
   const proxyUrl = new URL(proxy);
-  if (!/^https?:$/.test(proxyUrl.protocol)) {
-    throw new Error(`unsupported proxy protocol (${proxyUrl.protocol.slice(0, -1)}), oc honors HTTP and HTTPS proxies`);
-  }
+  assertHttpProxyProtocol(proxyUrl);
   return target.protocol === 'https:'
     ? httpsViaConnect(target, proxyUrl, headers, tlsOpts)
     : httpViaProxy(target, proxyUrl, headers);
@@ -410,10 +495,8 @@ const FETCH_HEADERS = {
 async function viaImpers(impers, target) {
   // Some sites (Reddit) 403 the chrome fingerprint but accept firefox, so a
   // blocked first attempt gets one cheap retry with a second identity.
-  const asking = (impersonate) => (url) => {
-    const proxy = resolveProxy(url);
-    return impers.get(url, { impersonate, allowRedirects: false, ...(proxy && { proxy }) });
-  };
+  const asking = (impersonate) => (url) =>
+    impers.get(url, { impersonate, allowRedirects: false, proxy: resolveProxy(url) ?? '' });
   let via = 'impers:chrome';
   let { res } = await followRedirects(asking('chrome'), target);
   let status = res.status ?? res.statusCode ?? 0;

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
 
-const { fetchPage, followRedirects } = await import('../src/fetch.js');
+const { fetchPage, followRedirects, resolveProxy, proxyGet } = await import('../src/fetch.js');
 
 const BLOCKED_MESSAGE = 'blocked: private or internal URL';
 
@@ -134,4 +137,237 @@ test('the readable-type gate accepts text and refuses binary, on either transpor
     assert.throws(() => assertReadableType(type), /not a page oc can read/, `expected ${type} to be refused`);
   }
   assert.throws(() => assertReadableType('image/png'), /image\/png/);
+});
+
+test('resolveProxy reads the usual env vars and honors NO_PROXY', () => {
+  const none = {};
+  assert.equal(resolveProxy('https://example.com', none), null);
+
+  assert.equal(
+    resolveProxy('https://example.com', { HTTPS_PROXY: 'http://proxy.corp:8080' }),
+    'http://proxy.corp:8080',
+  );
+  assert.equal(
+    resolveProxy('https://example.com', { HTTP_PROXY: 'http://proxy.corp:8080' }),
+    'http://proxy.corp:8080',
+  );
+  assert.equal(
+    resolveProxy('http://example.com', { HTTP_PROXY: 'http://proxy.corp:8080' }),
+    'http://proxy.corp:8080',
+  );
+  assert.equal(
+    resolveProxy('http://example.com', { HTTPS_PROXY: 'http://secure-proxy.corp:8080' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://example.com', { http_proxy: 'proxy.corp:8080' }),
+    'http://proxy.corp:8080',
+  );
+
+  assert.equal(
+    resolveProxy('https://example.com/foo', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: 'example.com' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://foo.example.com', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: '.example.com' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://elsewhere.test', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: 'example.com' }),
+    'http://proxy.corp:8080',
+  );
+  assert.equal(
+    resolveProxy('https://example.com', { HTTPS_PROXY: 'http://proxy.corp:8080', no_proxy: '*' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://example.com:8443', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: 'example.com:8443' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://example.com:8443', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: 'example.com:443' }),
+    'http://proxy.corp:8080',
+  );
+});
+
+test('a private page URL is still blocked when a proxy is configured', async () => {
+  // The proxy itself is often loopback; that must not punch a hole in the
+  // page-target guard. fetchPage rejects before any socket is opened.
+  const keys = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
+  const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+  for (const k of keys) delete process.env[k];
+  process.env.HTTP_PROXY = 'http://127.0.0.1:8080';
+  process.env.HTTPS_PROXY = 'http://127.0.0.1:8080';
+  try {
+    await assert.rejects(() => fetchPage('127.0.0.1'), new RegExp(BLOCKED_MESSAGE));
+    await assert.rejects(() => fetchPage('https://192.168.1.1/admin'), new RegExp(BLOCKED_MESSAGE));
+  } finally {
+    for (const k of keys) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  }
+});
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server.address().port));
+  });
+}
+
+test('proxyGet sends an absolute-URI GET to an HTTP proxy', async () => {
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push({
+      method: req.method,
+      url: req.url,
+      host: req.headers.host,
+      ua: req.headers['user-agent'],
+      auth: req.headers['proxy-authorization'],
+    });
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><title>via proxy</title></html>');
+  });
+  const port = await listen(proxy);
+  try {
+    const res = await proxyGet(
+      'http://example.test/page',
+      `http://user:secret@127.0.0.1:${port}`,
+      { 'user-agent': 'oc-test' },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'text/html');
+    assert.equal(await res.text(), '<html><title>via proxy</title></html>');
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, 'GET');
+    assert.equal(seen[0].url, 'http://example.test/page');
+    assert.equal(seen[0].host, 'example.test');
+    assert.equal(seen[0].ua, 'oc-test');
+    assert.equal(seen[0].auth, `Basic ${Buffer.from('user:secret').toString('base64')}`);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('proxyGet issues CONNECT for an HTTPS target and fails loud on a refused tunnel', async () => {
+  const seen = [];
+  const proxy = http.createServer();
+  proxy.on('connect', (req, socket) => {
+    seen.push({ url: req.url, auth: req.headers['proxy-authorization'] });
+    socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+    socket.end();
+  });
+  const port = await listen(proxy);
+  try {
+    await assert.rejects(
+      () => proxyGet('https://example.test/page', `http://127.0.0.1:${port}`),
+      /proxy CONNECT failed: 403/,
+    );
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].url, 'example.test:443');
+  } finally {
+    proxy.close();
+  }
+});
+
+// Self-signed localhost cert so the HTTPS success path can run offline. The
+// client is handed the same cert as `ca`, so verification stays on.
+const LOCAL_CERT = `-----BEGIN CERTIFICATE-----
+MIIBmDCCAT+gAwIBAgIUMrBi6hKtC1hrvo+Ttf70VHSofLkwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI2MDgyMzE1MzU1MFoXDTM2MDgyMDE1
+MzU1MFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAESbtFNb5R3K9iqcJJ6J9HII9DRylOGKutU+uoJ4TTsopcsRz2jMns8UYa
++oABlqC0ef+LAcaTwkPHgTwzfS1GuqNvMG0wHQYDVR0OBBYEFPPKq83hQvf8KTZB
+r0bMcGIo18wBMB8GA1UdIwQYMBaAFPPKq83hQvf8KTZBr0bMcGIo18wBMA8GA1Ud
+EwEB/wQFMAMBAf8wGgYDVR0RBBMwEYIJbG9jYWxob3N0hwR/AAABMAoGCCqGSM49
+BAMCA0cAMEQCIHBWYJSTt1qGyhySr2CY+JYWFdpApMvHVqED54/GivKcAiBchJFW
+8FrIy8Paiv8v+us5Ahlpr1QheS5LZX+LUWPUIg==
+-----END CERTIFICATE-----`;
+
+const LOCAL_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgtusH8iEEA2S7nGrF
+DrJVWIHwY2v4DoYibYK0wTwAQEuhRANCAARJu0U1vlHcr2Kpwknon0cgj0NHKU4Y
+q61T66gnhNOyilyxHPaMyezxRhr6gAGWoLR5/4sBxpPCQ8eBPDN9LUa6
+-----END PRIVATE KEY-----`;
+
+test('proxyGet returns the origin body through an HTTPS CONNECT tunnel', async () => {
+  // The 403 test above only proves we open the tunnel. This one proves the
+  // GET after TLS actually reaches the origin: the old path wrapped TLS twice
+  // and the origin never saw a request.
+  const originGot = [];
+  const origin = https.createServer({ cert: LOCAL_CERT, key: LOCAL_KEY }, (req, res) => {
+    originGot.push({ method: req.method, url: req.url, host: req.headers.host, ua: req.headers['user-agent'] });
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><title>via tunnel</title></html>');
+  });
+  const originPort = await listen(origin);
+
+  const connected = [];
+  const proxy = http.createServer();
+  proxy.on('connect', (req, socket) => {
+    connected.push(req.url);
+    const { hostname, port } = new URL(`http://${req.url}`);
+    const dest = net.connect(Number(port), hostname, () => {
+      socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      dest.pipe(socket);
+      socket.pipe(dest);
+    });
+    dest.on('error', () => socket.destroy());
+  });
+  const proxyPort = await listen(proxy);
+
+  try {
+    const res = await proxyGet(
+      `https://127.0.0.1:${originPort}/page`,
+      `http://127.0.0.1:${proxyPort}`,
+      { 'user-agent': 'oc-test' },
+      { ca: LOCAL_CERT },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'text/html');
+    assert.equal(await res.text(), '<html><title>via tunnel</title></html>');
+    assert.deepEqual(connected, [`127.0.0.1:${originPort}`]);
+    assert.deepEqual(originGot, [{
+      method: 'GET',
+      url: '/page',
+      host: `127.0.0.1:${originPort}`,
+      ua: 'oc-test',
+    }]);
+  } finally {
+    origin.close();
+    proxy.close();
+  }
+});
+
+test('followRedirects still blocks a private hop when the transport is a proxy', async () => {
+  // The page 302s to loopback. The proxy is also loopback, which is allowed;
+  // the hop is not. Blocked before the second request goes out.
+  let n = 0;
+  const proxy = http.createServer((req, res) => {
+    n += 1;
+    if (n === 1) {
+      res.writeHead(302, { location: 'http://127.0.0.1/admin' });
+      res.end();
+      return;
+    }
+    res.writeHead(200);
+    res.end('should not happen');
+  });
+  const port = await listen(proxy);
+  try {
+    await assert.rejects(
+      () => followRedirects((url) => proxyGet(url, `http://127.0.0.1:${port}`), 'http://public.example/start'),
+      new RegExp(BLOCKED_MESSAGE),
+    );
+    assert.equal(n, 1);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('proxyGet refuses a non-HTTP proxy scheme', () => {
+  assert.throws(
+    () => proxyGet('https://example.test/', 'socks5://127.0.0.1:1080'),
+    /unsupported proxy protocol \(socks5\)/,
+  );
 });

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -8,6 +8,19 @@ const { fetchPage, followRedirects, resolveProxy, proxyGet } = await import('../
 
 const BLOCKED_MESSAGE = 'blocked: private or internal URL';
 
+const PROXY_ENV_KEYS = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
+
+function withoutProxyEnv(run) {
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
+  return run().finally(() => {
+    for (const k of PROXY_ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  });
+}
+
 test('fetchPage blocks literal loopback and RFC 1918 / link-local hosts', async () => {
   const blocked = [
     'localhost',
@@ -30,11 +43,13 @@ test('fetchPage blocks literal loopback and RFC 1918 / link-local hosts', async 
 test('fetchPage does not block an ordinary public hostname', async () => {
   // A live fetch of example.com should succeed outright, or at worst fail for
   // a network reason - it must never be rejected by the private-URL guard.
-  try {
-    await fetchPage('example.com');
-  } catch (err) {
-    assert.ok(!err.message.includes(BLOCKED_MESSAGE), `unexpected block: ${err.message}`);
-  }
+  await withoutProxyEnv(async () => {
+    try {
+      await fetchPage('example.com');
+    } catch (err) {
+      assert.ok(!err.message.includes(BLOCKED_MESSAGE), `unexpected block: ${err.message}`);
+    }
+  });
 });
 
 test('fetchPage does not false-positive on a public hostname that merely starts with a private-looking numeric label', async () => {
@@ -44,11 +59,13 @@ test('fetchPage does not false-positive on a public hostname that merely starts 
   // 10.example.com (subdomain "10" of example.com) was wrongly blocked as if
   // it were 10.0.0.0/8. Validating the resolved address instead of the
   // string fixes this.
-  try {
-    await fetchPage('10.example.com');
-  } catch (err) {
-    assert.ok(!err.message.includes(BLOCKED_MESSAGE), `unexpected block: ${err.message}`);
-  }
+  await withoutProxyEnv(async () => {
+    try {
+      await fetchPage('10.example.com');
+    } catch (err) {
+      assert.ok(!err.message.includes(BLOCKED_MESSAGE), `unexpected block: ${err.message}`);
+    }
+  });
 });
 
 test('fetchPage blocks an IPv4-mapped IPv6 loopback literal', async () => {
@@ -78,7 +95,7 @@ const replies = (...hops) => {
   return { get, asked };
 };
 
-test('every redirect hop is re-validated, not just the original URL', async () => {
+test('every redirect hop is re-validated, not just the original URL', () => withoutProxyEnv(async () => {
   // An SSRF hides the real target behind a public-looking first hop, so the
   // check has to run again on what the 302 names. This used to be proven
   // against httpbin.org, which meant a third party's uptime could fail the
@@ -87,9 +104,9 @@ test('every redirect hop is re-validated, not just the original URL', async () =
   await assert.rejects(() => followRedirects(get, 'https://public.example/start'), new RegExp(BLOCKED_MESSAGE));
   // Blocked before the socket, not after: the private address is never asked for.
   assert.deepEqual(asked, ['https://public.example/start']);
-});
+}));
 
-test('a hop to somewhere public is followed', async () => {
+test('a hop to somewhere public is followed', () => withoutProxyEnv(async () => {
   // The other half of the guarantee. A loop that rejected everything would
   // pass the test above and break every redirect on the web.
   const { get, asked } = replies(
@@ -100,12 +117,12 @@ test('a hop to somewhere public is followed', async () => {
   assert.equal(res.status, 200);
   assert.equal(url, 'https://elsewhere.example/relative');
   assert.equal(asked.length, 3);
-});
+}));
 
-test('a redirect loop gives up instead of spinning', async () => {
+test('a redirect loop gives up instead of spinning', () => withoutProxyEnv(async () => {
   const get = () => Promise.resolve({ status: 302, headers: new Map([['location', 'https://public.example/again']]) });
   await assert.rejects(() => followRedirects(get, 'https://public.example/start'), /too many redirects/);
-});
+}));
 
 test('the readable-type gate accepts text and refuses binary, on either transport', async () => {
   const { assertReadableType } = await import('../src/fetch.js');
@@ -188,21 +205,123 @@ test('resolveProxy reads the usual env vars and honors NO_PROXY', () => {
     resolveProxy('https://example.com:8443', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: 'example.com:443' }),
     'http://proxy.corp:8080',
   );
+  assert.equal(
+    resolveProxy('http://[2606:4700::1]/', { HTTP_PROXY: 'http://proxy.corp:8080', NO_PROXY: '2606:4700::1' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('http://10.0.0.5/', { HTTP_PROXY: 'http://proxy.corp:8080', NO_PROXY: '10.0.0.0/8' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://foo.example.com', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: '*.example.com' }),
+    null,
+  );
+  assert.equal(
+    resolveProxy('https://example.com', { HTTPS_PROXY: 'http://proxy.corp:8080', NO_PROXY: '*.example.com' }),
+    'http://proxy.corp:8080',
+  );
+});
+
+test('resolveProxy rejects a socks proxy URL', () => {
+  assert.throws(
+    () => resolveProxy('https://example.com', { HTTP_PROXY: 'socks5://127.0.0.1:1080' }),
+    /unsupported proxy protocol \(socks5\)/,
+  );
 });
 
 test('a private page URL is still blocked when a proxy is configured', async () => {
   // The proxy itself is often loopback; that must not punch a hole in the
   // page-target guard. fetchPage rejects before any socket is opened.
-  const keys = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY', 'http_proxy', 'https_proxy', 'no_proxy'];
-  const prev = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
-  for (const k of keys) delete process.env[k];
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
   process.env.HTTP_PROXY = 'http://127.0.0.1:8080';
   process.env.HTTPS_PROXY = 'http://127.0.0.1:8080';
   try {
     await assert.rejects(() => fetchPage('127.0.0.1'), new RegExp(BLOCKED_MESSAGE));
     await assert.rejects(() => fetchPage('https://192.168.1.1/admin'), new RegExp(BLOCKED_MESSAGE));
   } finally {
-    for (const k of keys) {
+    for (const k of PROXY_ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  }
+});
+
+test('an unresolvable hostname is blocked when a proxy is configured', async () => {
+  // Internal names are often NXDOMAIN on the client but reachable via the
+  // corporate proxy. Without this, assertSafeTarget sees [] and the proxy
+  // fetches what the guard exists to stop.
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
+  process.env.HTTP_PROXY = 'http://127.0.0.1:8080';
+  try {
+    await assert.rejects(
+      () => fetchPage('http://intranet.invalid/admin'),
+      new RegExp(BLOCKED_MESSAGE),
+    );
+  } finally {
+    for (const k of PROXY_ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  }
+});
+
+test('fetchPage honors lowercase no_proxy and bypasses the proxy', async () => {
+  // Regression for the impers path: libcurl re-reads lowercase http_proxy from
+  // the environment when the proxy option is omitted. resolveProxy must stick,
+  // and impers must receive proxy: '' so curl does not override oc's decision.
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(502, { 'content-type': 'text/html' });
+    res.end('<html>via proxy</html>');
+  });
+  const port = await listen(proxy);
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
+  process.env.http_proxy = `http://127.0.0.1:${port}`;
+  process.env.no_proxy = '1.1.1.1';
+  try {
+    // Direct fetch may fail offline; the point is the proxy never sees the request.
+    await fetchPage('http://1.1.1.1/page').catch(() => {});
+    assert.equal(seen.length, 0);
+  } finally {
+    proxy.close();
+    for (const k of PROXY_ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  }
+});
+
+test('fetchPage routes through HTTP_PROXY instead of connecting directly', async () => {
+  // Wiring test: resolveProxy → proxyGet/viaFetch (or impers with proxy) must
+  // actually hit the configured proxy. Unit tests for resolveProxy and proxyGet
+  // alone would still pass if this branch were deleted. A public IP literal
+  // keeps assertSafeTarget offline-friendly (no DNS lookup for the target).
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push({ method: req.method, url: req.url, host: req.headers.host });
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><title>via fetchPage</title></html>');
+  });
+  const port = await listen(proxy);
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
+  process.env.HTTP_PROXY = `http://127.0.0.1:${port}`;
+  try {
+    const page = await fetchPage('http://1.1.1.1/page');
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].method, 'GET');
+    assert.equal(seen[0].url, 'http://1.1.1.1/page');
+    assert.equal(seen[0].host, '1.1.1.1');
+    assert.equal(page.html, '<html><title>via fetchPage</title></html>');
+    assert.equal(page.status, 200);
+  } finally {
+    proxy.close();
+    for (const k of PROXY_ENV_KEYS) {
       if (prev[k] === undefined) delete process.env[k];
       else process.env[k] = prev[k];
     }
@@ -244,6 +363,46 @@ test('proxyGet sends an absolute-URI GET to an HTTP proxy', async () => {
     assert.equal(seen[0].host, 'example.test');
     assert.equal(seen[0].ua, 'oc-test');
     assert.equal(seen[0].auth, `Basic ${Buffer.from('user:secret').toString('base64')}`);
+  } finally {
+    proxy.close();
+  }
+});
+
+test('proxyGet strips page URL credentials from the absolute-URI request line', async () => {
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html></html>');
+  });
+  const port = await listen(proxy);
+  try {
+    await proxyGet(
+      'http://alice:s3cr3t@example.test/private',
+      `http://127.0.0.1:${port}`,
+    );
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0], 'http://example.test/private');
+  } finally {
+    proxy.close();
+  }
+});
+
+test('proxyGet tolerates an unencoded percent in proxy credentials', async () => {
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push({ auth: req.headers['proxy-authorization'] });
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html></html>');
+  });
+  const port = await listen(proxy);
+  try {
+    await proxyGet(
+      'http://example.test/page',
+      `http://user:pa%ss@127.0.0.1:${port}`,
+      { 'user-agent': 'oc-test' },
+    );
+    assert.equal(seen[0].auth, `Basic ${Buffer.from('user:pa%ss').toString('base64')}`);
   } finally {
     proxy.close();
   }


### PR DESCRIPTION
## Summary
- Honor `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` for both impers and native fetch paths
- Keep SSRF checks on page targets; proxy hosts are not blocked
- Add offline proxy tests and README note

Closes #9

## Test plan
- [x] `npm test`