### PR TITLE
Add the MIT LICENSE file the badge and package.json were claiming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 only-cli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![A tangle of raw HTML being funneled into a small, tidy terminal window](docs/hero.jpg)
 
-[![npm](https://img.shields.io/npm/v/%40only-cli%2Foc)](https://www.npmjs.com/package/@only-cli/oc) [![node](https://img.shields.io/node/v/%40only-cli%2Foc)](https://nodejs.org) [![license: MIT](https://img.shields.io/badge/license-MIT-green)](#license) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/only-cli/oc/badge)](https://scorecard.dev/viewer/?uri=github.com/only-cli/oc)
+[![npm](https://img.shields.io/npm/v/%40only-cli%2Foc)](https://www.npmjs.com/package/@only-cli/oc) [![node](https://img.shields.io/node/v/%40only-cli%2Foc)](https://nodejs.org) [![license: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/only-cli/oc/badge)](https://scorecard.dev/viewer/?uri=github.com/only-cli/oc)
 
 Turns websites into a command line interface for AI agents. `oc open <url>` fetches a page and hands back a compact, numbered view instead of raw HTML or a screenshot, so agents like Claude Code, Codex, and Antigravity can browse without burning tokens. It also gets past blocks that stop naive fetchers on some sites, by talking to the page the way a real browser would.
 
@@ -118,4 +118,4 @@ Known limits, honestly: no JavaScript rendering yet, no sites behind logins yet,
 
 ## License
 
-MIT
+MIT, see [LICENSE](LICENSE).


### PR DESCRIPTION
## What and why

Closes #15. `README.md` and `package.json` both declared MIT, but there was no LICENSE file, so `gh api repos/only-cli/oc --jq .license` returned null and the code was, as far as tooling and downstream users are concerned, all rights reserved. That is exactly the case that blocks the cautious users: vendoring `oc`, shipping it inside a corporate toolchain, or clearing a license audit. The published `@only-cli/oc` tarball already carries `"license": "MIT"`, so the package and the repository disagreed.

- adds a standard MIT `LICENSE` at the root, copyright "2026 only-cli"
- points the README badge at `LICENSE` instead of the `#license` anchor, which is also what the OpenSSF Scorecard License check reads
- the License section now names the file

If the copyright line should read differently (a legal name, or a different year), say so and I will amend it: that is the one line here only the copyright holder can decide.

## Checklist

- [x] `--stats` before/after on a fixture, if this changes what a page renders (see CONTRIBUTING.md, "It respects the token budget"): n/a, no code change
- [x] No new dependency, or a one-line justification here if there is one
- [x] New behavior has a fixture in `tests/pages/` and a test in `tests/`: n/a, no behavior change
- [x] `npm test` passes (80/80)
- [x] `npm run typecheck` passes: no such script on `main` yet, and no code changed
- [x] If this touches `clis/*.json`: it does not
