### PR TITLE
Fail loud when a page distills to no readable content

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Flags: `--budget <tokens>` (default 500), `--json`, `--html` (raw as cleaned HTM
 
 `oc open` remembers the page it rendered in a JSON file per session under `~/.only-cli` (override with `OC_HOME`), so `oc do 3` follows `[3]` without the agent ever handling a URL. A result title on a search page is a link, so `oc do` on it opens the result rather than repeating the title. Pages longer than the budget say what they left out; `oc find`, `oc read <n>`, and `oc next` read the rest without refetching the page, and a `find` with a single match prints that region instead of the number to read it with. The budget is a target rather than a hard cap: a page that would only run a little long is printed whole rather than cut, since one extra tool call costs far more than the tokens it would have saved.
 
+When a page comes back with no readable text (JavaScript-only, a consent wall, a bot challenge), `oc` says so in one line on stderr and exits 2 instead of printing a title and calling it a render. That is a different exit code from every other failure, and `--json` carries the same verdict as an `empty` field, so an agent can tell "this page has nothing on it" from "oc could not read this page" and pay for a browser only when it is worth it.
+
 ## Supported websites
 
 Works on any mostly-static site with no per-site setup: news sites, blogs, documentation, forums, search engines. A JSON API is a page here too: `oc open` on an endpoint that answers with JSON renders one numbered item per record, keeps the fields that actually differ between items, and says once what every item shares. On top of that, `clis/` ships tuned shortcuts for:

--- a/llms.txt
+++ b/llms.txt
@@ -12,6 +12,7 @@ Key facts:
 - Benchmarked at roughly 45x fewer tokens than reading raw HTML, with per-task numbers at https://github.com/only-cli/benchmarks
 - Works on any mostly-static website; tuned shortcuts ship for Hacker News, Reddit, GitHub, X, LinkedIn (public guest views), DuckDuckGo, Bing, Stack Overflow (via its Atom feeds and the Stack Exchange API), Yahoo Finance (quotes, history, markets), and the AWS, Google Cloud, and Microsoft Learn documentation sites (guides, CLI reference, and search)
 - JSON APIs render like pages: an endpoint that answers with JSON becomes one numbered item per record, with the fields that differ between items kept and the ones every item shares stated once, so a search endpoint reads like a results page for a few hundred tokens
+- A page that comes back with no readable text (JavaScript-only, a consent wall, a bot challenge) prints one line on stderr and exits 2, rather than reporting an empty render as a success. `--json` carries the same verdict as an `empty` field, so a caller can tell "nothing on this page" from "oc could not read this page" and fall back to a browser only when it is worth it
 - X profiles and individual posts read without a login (about 390 and 260 tokens); X search, explore, and hashtag pages do not, and oc reports the block instead of guessing
 - Requests impersonate Chrome, so pages that block plain scripts often still work
 - Agent skill included: `npx skills add https://github.com/only-cli/oc --skill web-browsing-cli` ([skills.sh](https://www.skills.sh/only-cli/oc/web-browsing-cli))

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@
 import { parseArgs } from 'node:util';
 import { fetchPage } from './fetch.js';
 import { distill, toMarkdown, toHTML } from './distill.js';
-import { render, estimateTokens } from './render.js';
+import { render, estimateTokens, contentTokens, contentFailure, MIN_CONTENT } from './render.js';
 import * as act from './act.js';
 import { DEFAULT_SESSION, loadSession, saveSession, sessionFromPage } from './session.js';
 
@@ -35,6 +35,10 @@ flags:
                       globally. Off by default because metrics cost tokens too.
   --session <name>    keep separate page state under a name (default: default)
 
+A page that comes back with no readable text (JavaScript-only, a consent wall,
+a bot challenge) says so in one line on stderr and exits 2, so a caller can
+tell an empty page from a page oc could not read and fall back to a browser.
+
 'oc open' remembers the page it printed, so 'oc do 3' follows link [3] without
 you ever handling its URL, and 'oc next' or 'oc read 12' picks up what the
 budget left behind without fetching it again. 'oc do' on a search result title
@@ -59,6 +63,17 @@ const remember = (page, name, cursor) => {
 // What browsing costs without this tool is the raw page HTML in context.
 const savings = (out, raw) =>
   `~${out} tokens vs ~${raw} for the page HTML (${Math.max(0, 100 - Math.round((out / Math.max(raw, 1)) * 100))}% saved)`;
+
+// Nonzero, and distinct from the exit 1 that every other failure uses, so a
+// caller can branch on 'oc could not read this' without parsing prose.
+const NO_CONTENT_EXIT = 2;
+
+const noContent = (url, detail, hint = "; 'oc raw' has the page's markdown if there is any, otherwise this one needs a browser") => {
+  console.error(`oc: no readable content at ${url} (${detail}), so it is JavaScript-only, gated, or challenged${hint}`);
+  // Not process.exit: stdout may still be draining, and whatever did render is
+  // worth printing even when the render failed.
+  process.exitCode = NO_CONTENT_EXIT;
+};
 
 async function main() {
   const { values, positionals } = parseArgs({
@@ -123,27 +138,49 @@ async function main() {
         return `HTTP ${status} via ${via}, fetch ${Math.round(fetchMs)}ms, process ${Math.round(processMs)}ms, `
           + `${Math.round(html.length / 1024)}KB transferred, ${Math.round(rss / 1048576)}MB memory`;
       };
+      const htmlTokens = estimateTokens(html);
       if (values.json) {
         const page = distill(html, finalUrl);
         remember(page, sessionName);
-        console.log(JSON.stringify(page));
+        const failure = contentFailure(contentTokens(page), htmlTokens);
+        // Always present, so a caller can branch on the field rather than on
+        // whether a field it was hoping for turned up.
+        console.log(JSON.stringify({ ...page, empty: failure != null }));
         if (verbose) console.error(resources());
+        if (failure) noContent(finalUrl, failure);
         return;
       }
-      const htmlTokens = estimateTokens(html);
       if (command === 'raw') {
         const out = values.html ? toHTML(html, finalUrl) : toMarkdown(html, finalUrl);
+        const outTokens = estimateTokens(out);
         console.log(out);
-        if (verbose) console.error(`${savings(estimateTokens(out), htmlTokens)}; ${resources()}`);
+        if (verbose) {
+          const cost = outTokens < MIN_CONTENT
+            ? `nothing distilled out of ~${htmlTokens} tokens of page HTML`
+            : savings(outTokens, htmlTokens);
+          console.error(`${cost}; ${resources()}`);
+        }
+        // Only the blank case here. `raw` is the fallback the compact view's
+        // failure line names, so it must not fail on the same pages: a page
+        // whose only text is its menu still has markup, and printing it is the
+        // whole point of `raw`.
+        if (outTokens < MIN_CONTENT) noContent(finalUrl, `~${outTokens} tokens of markdown`, '');
         return;
       }
       const page = distill(html, finalUrl);
+      const failure = contentFailure(contentTokens(page), htmlTokens);
       const { text, stats } = render(page, { budget });
       remember(page, sessionName, stats.next);
       console.log(text);
       if (verbose) {
-        console.error(`~${stats.tokens} tokens, ${stats.rendered}/${stats.blocks} blocks rendered, ${savings(stats.tokens, htmlTokens)}; ${resources()}`);
+        // Reporting '100% saved' of a render that extracted nothing is the one
+        // place this line lies, and it lies in the tool's own favour.
+        const cost = failure
+          ? `no content distilled out of ~${htmlTokens} tokens of page HTML`
+          : savings(stats.tokens, htmlTokens);
+        console.error(`~${stats.tokens} tokens, ${stats.rendered}/${stats.blocks} blocks rendered, ${cost}; ${resources()}`);
       }
+      if (failure) noContent(finalUrl, failure);
       return;
     }
     case 'read': return console.log(act.read(Number(args[0]), { session: sessionName, budget: asked || 2000 }));

--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,62 @@ export const estimateTokens = (s) => Math.ceil(s.length / 4);
 
 const num = (v) => v.toLocaleString('en-US');
 
+// A page that distilled to nothing must not read like a page with nothing on
+// it. JS-only pages, consent walls, and bot challenges all answer HTTP 200 with
+// markup carrying no text, and "100% saved" is technically true of a render
+// that saved every token by extracting none. From the output alone an agent
+// cannot tell that from a genuinely empty page, so it never falls back to
+// something heavier and an empty result travels on as evidence. oc has to fail
+// loud and cheap there instead, per principle 5 in CONTRIBUTING.
+//
+// The numbers below are measured, not guessed. Against live pages, the thinnest
+// render the README claims (an X profile) carries about 460 tokens of content,
+// while a JS-only or gated one carries under 55 (reddit.com/r/*,
+// instagram.com), so a threshold in between never has to be a close call.
+
+// Text the page itself wrote, in tokens: prose and headings, plus link and
+// button labels long enough to be content rather than furniture. Nav chrome is
+// short by nature ("Help", "Log in") and a headline or a post title is not,
+// which is what tells a link-list page (Hacker News, search results) from a
+// page whose only links are its own menu.
+const CONTENT_LABEL = 25;
+// Below this there is nothing to read whatever the page is, so how much markup
+// it arrived in does not matter.
+export const MIN_CONTENT = 25;
+// Below this, with markup that large behind it, the fetch worked and the render
+// did not: a real page of that weight always distills to more. A genuinely
+// short page is exempt, because its HTML never reaches THIN_HTML.
+const THIN_CONTENT = 100;
+const THIN_HTML = 2500;
+
+/**
+ * How much of a distilled page is text the page itself wrote.
+ * @param {import('./distill.js').Page} page
+ * @returns {number}
+ */
+export const contentTokens = (page) =>
+  page.blocks.reduce((sum, b) => {
+    if (b.type === 'heading' || b.type === 'text') return sum + estimateTokens(b.text ?? '');
+    const label = (b.type === 'link' || b.type === 'button') && (b.text ?? '').length > CONTENT_LABEL;
+    return label ? sum + estimateTokens(b.text) : sum;
+  }, 0);
+
+/**
+ * Why this render carries no content worth printing, as a phrase for the
+ * failure line, or null when it does carry some. Both figures are token counts,
+ * which is the unit the caller is paying in.
+ * @param {number} content
+ * @param {number} htmlTokens
+ * @returns {string|null}
+ */
+export function contentFailure(content, htmlTokens) {
+  if (content < MIN_CONTENT) return `~${content} tokens of text on the whole page`;
+  if (content < THIN_CONTENT && htmlTokens > THIN_HTML) {
+    return `~${content} tokens of text out of ~${htmlTokens} of HTML`;
+  }
+  return null;
+}
+
 // How far past the budget a page may run and still be printed whole. Cutting a
 // page that was nearly done costs the agent a second command, and a command is
 // dear: measured inside Claude Code, one tool call is 23,000 to 33,000 tokens of

--- a/tests/distill.test.js
+++ b/tests/distill.test.js
@@ -1,9 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { distill, toMarkdown, toHTML, feedToHTML, jsonToHTML, youtubeToHTML, transcriptToHTML, TEXT_CAP } from '../src/distill.js';
-import { render, estimateTokens } from '../src/render.js';
+import { render, estimateTokens, contentTokens, contentFailure } from '../src/render.js';
 
+const PAGES = new URL('./pages/', import.meta.url).pathname;
 const html = readFileSync(new URL('./pages/news.html', import.meta.url), 'utf8');
 const page = () => distill(html, 'https://example.test/news');
 const feed = readFileSync(new URL('./pages/feed.xml', import.meta.url), 'utf8');
@@ -475,4 +476,53 @@ test('a truncated code block ends on a line, not mid-statement', () => {
   // The kept part stops where a statement did, so every line shown is whole.
   assert.ok(shown[marker].startsWith('line'), `cut mid-line: ${shown[marker]}`);
   assert.ok(shown[marker].includes(');'), `cut mid-statement: ${shown[marker]}`);
+});
+
+test('a page that arrives with no readable text is reported as a failure', () => {
+  // The failure mode issue #14 reports: HTTP 200, real markup, nothing to read.
+  // It has to be distinguishable from a page that renders short, because the
+  // caller's next move (fall back to a browser) depends on the difference.
+  const verdict = (body, size) => {
+    const filler = `<script>const pad = "${'x'.repeat(size)}";</script>`;
+    const page = distill(`<html><head><title>Reddit</title></head><body>${body}${filler}</body></html>`,
+      'https://fixture.test/js');
+    return contentFailure(contentTokens(page), estimateTokens(filler));
+  };
+
+  // Nothing at all, whatever the page weighed.
+  assert.match(verdict('<div id="root"></div>', 0), /~0 tokens of text on the whole page/);
+
+  // Menu links only: short labels are furniture, so this page has no content
+  // either, however much markup came with it.
+  const chrome = ['Help', 'Log in', 'Content Policy', 'About', 'Careers', 'Press']
+    .map((t) => `<a href="/${t}">${t}</a>`).join('');
+  assert.match(verdict(chrome, 60_000), /~0 tokens of text on the whole page/);
+
+  // A consent wall or a login gate: a sentence or two of real text, out of
+  // markup far too big to have carried only that.
+  const gate = '<p>To continue, accept cookies. We and our partners store and access '
+    + 'information on your device to personalise the content you see here.</p>';
+  assert.match(verdict(gate, 60_000), /tokens of text out of ~\d+ of HTML/);
+  // The same page without that weight behind it is a short page, not a failed
+  // render, so it has to pass.
+  assert.equal(verdict(gate, 0), null);
+});
+
+test('a link-list page counts as content even with no prose on it', () => {
+  // Hacker News and search results are links and nothing else, so a rule that
+  // counted only prose would call the tool's best pages empty.
+  const links = Array.from({ length: 12 }, (_, i) =>
+    `<a href="/${i}">A headline long enough to be a headline, number ${i}</a>`).join('');
+  const page = distill(`<html><body>${links}</body></html>`, 'https://fixture.test/list');
+  assert.equal(contentFailure(contentTokens(page), 30_000), null);
+});
+
+test('every fixture page reads as content, none as a failed render', () => {
+  // Feeds, a JSON API, and a YouTube watch page are all thin by design, which
+  // is exactly where this check must not cry wolf.
+  for (const name of readdirSync(PAGES)) {
+    const raw = readFileSync(PAGES + name, 'utf8');
+    const page = distill(raw, `https://api.example.test/2.3/search/advanced?site=fixture&f=${name}`);
+    assert.equal(contentFailure(contentTokens(page), estimateTokens(raw)), null, name);
+  }
 });


### PR DESCRIPTION
Closes #14.

## The problem

A JavaScript-only page, a consent wall, and a bot challenge all answer HTTP 200 with markup that carries no text. `oc` rendered those as successes: a title, an `actions:` line, and in verbose mode `100% saved`, which is technically true of a render that saved every token by extracting none. From the output alone an agent cannot tell that from a page that is genuinely empty, so it never falls back to anything heavier and the empty result travels on as evidence. That is exactly what principle 5 in CONTRIBUTING ("fail loud and cheap") exists to prevent.

```
$ oc open https://www.reddit.com/r/ClaudeAI/     # before
# Reddit
actions: do <n> | read <n> | raw
$ echo $?
0
```

## The change

```
$ oc open https://www.reddit.com/r/ClaudeAI/     # after
# Reddit
actions: do <n> | read <n> | raw
oc: no readable content at https://www.reddit.com/r/ClaudeAI/ (~47 tokens of text out of ~41739 of HTML), so it is JavaScript-only, gated, or challenged; 'oc raw' has the page's markdown if there is any, otherwise this one needs a browser
$ echo $?
2
```

- One line on stderr, so it costs nothing in the normal case and does not disturb whatever stdout printed.
- **Exit 2**, distinct from the exit 1 every other failure uses, so a caller can branch on "oc could not read this" without parsing prose. Set via `process.exitCode`, not `process.exit`, so stdout is never truncated.
- `--json` grows an always-present `empty` boolean, so a caller branches on the field rather than on whether a field it hoped for turned up.
- `oc raw` fails only on genuinely blank output. Raw is the fallback the compact view's failure line names, so it must not refuse the same pages: a nav-only page still has markup and printing it is the point.

## The thresholds are measured

`contentTokens` counts text the page itself wrote: prose and headings, plus link and button labels over 25 characters. Nav chrome is short by nature ("Help", "Log in") while a headline or post title is not, which is what tells a link-list page (Hacker News, search results) from a page whose only links are its own menu. A pure HTML-to-output ratio test was tried first and rejected: it false-positives on script-heavy pages that do carry real content.

| page | content tokens | verdict |
| --- | ---: | --- |
| `www.reddit.com/r/ClaudeAI/` | 47 | failure |
| `instagram.com` | 51 | failure |
| `x.com/AnthropicAI` (thinnest page the README claims) | 463 | ok |
| `en.wikipedia.org/wiki/Web_scraping` | 3,600 | ok |

The gap is wide, so neither threshold has to sit close to anything: a hard floor at 25 tokens, plus a thin-content rule at under 100 tokens when the HTML behind it exceeded 2,500 (a genuinely short page never reaches that, so it is exempt).

## Verification

- `node --test`: 83 passing, up from 80. Three new tests in `tests/distill.test.js` cover an empty-root JS page, a nav-chrome-only page, a consent wall landing in the thin band, the same wall with light HTML reading as fine, a link-list page counting as content with no prose on it, and a sweep asserting every shipped fixture reads as content.
- Live, both reported cases now exit 2 while `old.reddit.com/r/ClaudeAI/` (1,557 tokens) stays 0.
- No false positives on ten thin-by-design surfaces: `example.com`, Stack Overflow Atom feeds, the Stack Exchange API, Microsoft Learn RSS, a YouTube watch page, AWS and GCP docs pages, and a one-line HN item.
