### PR TITLE
feat: add wikipedia site shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Works on any mostly-static site with no per-site setup: news sites, blogs, docum
 | Stack Overflow | `oc so` (via Atom feeds and the Stack Exchange API) | `search <query>`, `question <id>`, `tag <name>`, `user <id>`, `recent` |
 | Yahoo Finance | `oc yahoo` | `quote <symbol>`, `news <symbol>`, `history <symbol>`, `lookup <query>`, `markets`, `gainers`, `losers`, `trending` |
 | YouTube | `oc yt` | `video <id>`, `channel <name>` |
+| Wikipedia | `oc wiki` (via `action=render`) | `article <title>`, `search <query>`, `lang <code> <title>` |
 | AWS docs | `oc aws` (search via DuckDuckGo) | `guide <service> <page>`, `page <service> <guide> <page>`, `cli <command>`, `search <query>` |
 | Google Cloud docs | `oc gcp` (via docs.cloud.google.com, search via DuckDuckGo) | `docs <product>`, `page <product> <page>`, `gcloud <command>`, `search <query>` |
 | Microsoft Learn | `oc learn` (search via its RSS API) | `azure <page>`, `doc <path>`, `cli <command>`, `search <query>` |

--- a/clis/wikipedia.org.json
+++ b/clis/wikipedia.org.json
@@ -1,0 +1,8 @@
+{
+  "domain": "wikipedia.org",
+  "commands": {
+    "article": { "open": "https://en.wikipedia.org/w/index.php?title={title}&action=render", "args": ["title"] },
+    "search": { "open": "https://en.wikipedia.org/w/index.php?search={query}&fulltext=1&ns0=1", "args": ["query"] },
+    "lang": { "open": "https://{code}.wikipedia.org/w/index.php?title={title}&action=render", "args": ["code", "title"] }
+  }
+}

--- a/src/sites.js
+++ b/src/sites.js
@@ -24,6 +24,7 @@ const ALIASES = {
   aws: 'docs.aws.amazon.com',
   gcp: 'cloud.google.com',
   learn: 'learn.microsoft.com',
+  wiki: 'wikipedia.org',
 };
 
 /** @typedef {{open: string, args?: string[]}} Shortcut */


### PR DESCRIPTION
Closes #21.

Adds `clis/wikipedia.org.json` with three commands, plus a `wiki` alias in `src/sites.js` and a README row:

- `oc wiki article <title>`
- `oc wiki search <query>`
- `oc wiki lang <code> <title>` for the non English wikis

`oc wikipedia` and `oc wikipedia.org` resolve from the domain as usual.

### Why `?action=render`

`/wiki/<Title>` spends roughly half a 500 token budget on the interlanguage sidebar and the Tools menu before reaching any article text (70 blocks rendered, about 40 of them chrome). `?action=render` returns the article HTML alone, so the budget goes to content, and its links stay root relative so `oc do <n>` keeps working.

The Parsoid endpoints (`/api/rest_v1/page/html/`, `/w/rest.php/v1/page/.../html`) distill just as clean and even keep the page title, but they emit `./Title` hrefs. Those resolve against the API path, so `oc do 1` asks for `/w/rest.php/v1/page/Claude_(AI)/Programmer` and gets a 404. The cost is that `action=render` ships no `<title>`, which is a fair trade for links that work.

### Why search stays on the HTML page

Now that `oc open` reads JSON, `api.php?action=query&list=search` looked like the cheaper option. It is not usable yet: its results sit in a nested `query.search` array, so the page distills to 2 blocks and exits 2 with "no readable content". The HTML results page costs more but actually lists the results, so search points there until nested JSON arrays render.

### Checks

- rebased onto current `main` (`71b032b`), which had moved since this branch was cut
- `node --test` passes (92 tests), `lint:clis` clean across all 14 definitions
- verified live on the rebased tree: `article`, `search`, `lang de Berlin`, and `oc do 1` off an article page
