### PR TITLE
release: 0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "only-cli",
       "source": { "source": "github", "repo": "only-cli/oc" },
       "description": "Browse websites from the terminal in a few hundred tokens",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "homepage": "https://github.com/only-cli/oc",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "only-cli",
   "description": "Browse websites from the terminal in a few hundred tokens",
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes per release. Releases before 0.4.0 are listed at
 [github.com/only-cli/oc/releases](https://github.com/only-cli/oc/releases).
 
-## Unreleased
+## 0.5.0
 
 ### Added
 
@@ -13,6 +13,31 @@ Notable changes per release. Releases before 0.4.0 are listed at
   index locally and on `mdn` asks the site's API; the sites that only render
   docs search client-side go through DuckDuckGo with a baked-in `site:` filter
   instead. (#25)
+- Authenticated sessions: `oc login` seeds cookies for a session and every
+  fetch in that session sends them; `oc logout` forgets a session early,
+  cookies and saved page both. Cookies live in a per-session jar under
+  `OC_HOME`, separate from page state, pinned to the exact host they were
+  seeded for, and marked secure by default so they travel over https only
+  (`--allow-http` at login opts a plain-http site in). A session lasts an hour
+  unless `--expires` says otherwise. `--cookie -` reads the header from stdin,
+  the form to prefer since an argv secret is visible in `ps` and kept in shell
+  history. (#4)
+
+### Fixed
+
+- Response bodies are bounded at every transport, 25MB decoded, checked
+  against `Content-Length` before the bytes arrive and counted as they land,
+  so a hostile URL is no longer an unbounded allocation and a decompression
+  bomb stops at the cap. (#27)
+- Titles, headings, and input names are cut at the render boundary like every
+  other block, so one hostile page-written scalar can no longer print
+  unbounded output whatever the budget said. The distilled page keeps the
+  full values and `--json` stays the machine-stable view. (#28)
+- A short page is judged unreadable by evidence, not by length alone: nothing
+  extracted is empty whatever the page weighed, and a short render only fails
+  when the markup behind it was far too big to have carried only that. A
+  status endpoint or a one-line answer now exits 0; script-only shells and
+  consent walls still exit 2. (#29)
 
 ## 0.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@only-cli/oc",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "linkedom": "^0.18.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Turn websites into a compact CLI so AI agents can browse without burning tokens.",
   "type": "module",
   "bin": {

--- a/skills/web-browsing-cli/SKILL.md
+++ b/skills/web-browsing-cli/SKILL.md
@@ -8,15 +8,15 @@ description: Token-efficient web browsing and web content extraction for AI agen
 Renders a web page as a compact, numbered terminal view instead of raw HTML. A typical page is under 500 tokens.
 
 ```
-npx --yes @only-cli/oc@0.4.0 open <url>     compact view, numbered elements
-npx --yes @only-cli/oc@0.4.0 do <n>         follow link [n], or read it if [n] is text
-npx --yes @only-cli/oc@0.4.0 find <query>   where a string appears, or that place itself
+npx --yes @only-cli/oc@0.5.0 open <url>     compact view, numbered elements
+npx --yes @only-cli/oc@0.5.0 do <n>         follow link [n], or read it if [n] is text
+npx --yes @only-cli/oc@0.5.0 find <query>   where a string appears, or that place itself
                                             when only one matches
-npx --yes @only-cli/oc@0.4.0 next           next ~500 tokens of the page already open
-npx --yes @only-cli/oc@0.4.0 read <n>       full text of region [n]
-npx --yes @only-cli/oc@0.4.0 raw [url]      whole page as markdown (--html for cleaned HTML)
-npx --yes @only-cli/oc@0.4.0 login            seed cookies (--cookie, --domain, --expires)
-npx --yes @only-cli/oc@0.4.0 logout [session] forget a session: cookies and saved page
+npx --yes @only-cli/oc@0.5.0 next           next ~500 tokens of the page already open
+npx --yes @only-cli/oc@0.5.0 read <n>       full text of region [n]
+npx --yes @only-cli/oc@0.5.0 raw [url]      whole page as markdown (--html for cleaned HTML)
+npx --yes @only-cli/oc@0.5.0 login            seed cookies (--cookie, --domain, --expires)
+npx --yes @only-cli/oc@0.5.0 logout [session] forget a session: cookies and saved page
 ```
 
 None of these except `open`/`do`/`raw <url>` fetch anything; they replay the page `open` already saved.


### PR DESCRIPTION
Cuts 0.5.0 and brings the docs up to date with everything merged since 0.4.0.

## Version

0.5.0 in `package.json`, the lockfile, `.claude-plugin/plugin.json`, the marketplace entry, and the `npx --yes @only-cli/oc@...` pins inside the skill.

## CHANGELOG

Covers 0.5.0 against 0.4.0:

- #25 language documentation shortcuts: `py`, `mdn`, `node`, `ruby`, `go`, `rust`, `java`, `php`, `cpp`, and `ts`, plus a `dotnet` verb on `learn`. Search ranks the docs' own index locally where the site ships one (Sphinx, RDoc, the Node.js reference), asks MDN's own API, and falls back to DuckDuckGo with a `site:` filter where docs search only renders client-side
- #4 authenticated sessions via per-session cookie jars: `oc login` seeds cookies, every fetch in that session sends them, `oc logout` forgets cookies and saved page both
- #27 response bodies bounded at every transport, so a hostile URL is no longer an unbounded allocation
- #28 titles, headings, and input names cut at the render boundary like every other block
- #29 a short page is judged unreadable by evidence, not by length alone, so a terse but real answer exits 0

The skill and README were updated inside the feature PRs, so this release carries no separate doc rewrite beyond the changelog and the version pins.

## Checks

`npm test` passes 183/183. Smoke tested from this branch: `oc sites` lists the ten new language rows, and `oc py search json dumps` ranks the `json` module first from the docs' own index.
