### PR TITLE
ci: bump github/codeql-action to v4.37.8, group its Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # init and analyze must run the same version, so bump them in one PR.
+      codeql-action:
+        patterns:
+          - github/codeql-action*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: github/codeql-action/init@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/analyze@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@42947a340483f03ba47bb1a039b2c519aab3df85 # v3.37.8
+      - uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Replaces #34 and #35. Those bumped `analyze` and `init` in separate PRs, and each failed with:

    Loaded a configuration file for version '4.37.8', but running version '3.37.8'

`init` and `analyze` must run the same version of the action, so they have to move together. This PR:

- bumps `init`, `analyze` and `upload-sarif` (in `scorecard.yml`) to v4.37.8 at the same SHA Dependabot resolved (`db488dd`, verified against the annotated `v4.37.8` tag)
- adds a Dependabot `groups` rule for `github/codeql-action*` so future bumps arrive as one PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)