### PR TITLE
fix: fall back to firefox, then plain fetch, when impers refuses a fingerprint

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -555,9 +555,24 @@ function captureSetCookie(jar, url, res) {
   jar.storeFromResponse(url, getSetCookieHeaders(res));
 }
 
-async function viaImpers(impers, target, jar) {
+/**
+ * Fetch a page through impers, downgrading identity when one is refused.
+ * Exported so the downgrade chain can be proven against a fake impers; the
+ * real entry point is fetchPage.
+ * @param {any} impers - the impers module (or a stand-in with a get method)
+ * @param {string} target
+ * @param {object} [jar]
+ * @returns {Promise<{url: string, html: string, status: number, via: string}>}
+ */
+export async function viaImpers(impers, target, jar) {
   // Some sites (Reddit) 403 the chrome fingerprint but accept firefox, so a
-  // blocked first attempt gets one cheap retry with a second identity.
+  // blocked first attempt gets one cheap retry with a second identity. An
+  // ImpersonateError is the same story one layer down: impers resolves the
+  // 'chrome' alias to its newest fingerprint, but the native library it loads
+  // can be an older system copy of libcurl-impersonate that predates that
+  // fingerprint and refuses it before any request leaves. Firefox aliases to
+  // an older target that such a library usually still knows, and when both
+  // identities are refused the plain fetch transport still gets the page.
   const asking = (impersonate) => (url) =>
     impers.get(url, {
       impersonate,
@@ -566,14 +581,23 @@ async function viaImpers(impers, target, jar) {
       headers: jarHeaders(jar, url, {}),
     });
   const onResponse = (url, res) => captureSetCookie(jar, url, res);
+  const attempt = async (impersonate) => {
+    try {
+      const { res } = await followRedirects(asking(impersonate), target, { onResponse });
+      return { res, status: res.status ?? res.statusCode ?? 0 };
+    } catch (err) {
+      if (err?.name !== 'ImpersonateError') throw err;
+      return null;
+    }
+  };
   let via = 'impers:chrome';
-  let { res } = await followRedirects(asking('chrome'), target, { onResponse });
-  let status = res.status ?? res.statusCode ?? 0;
-  if (status >= 400) {
+  let got = await attempt('chrome');
+  if (!got || got.status >= 400) {
     via = 'impers:firefox';
-    ({ res } = await followRedirects(asking('firefox'), target, { onResponse }));
-    status = res.status ?? res.statusCode ?? 0;
+    got = (await attempt('firefox')) ?? got;
   }
+  if (!got) return viaFetch(target, jar);
+  const { res, status } = got;
   if (status >= 400) throw new Error(`fetch failed: ${status} for ${target}`);
   assertReadableType(res.headers.get('content-type'));
   assertBodySize(Number(res.headers.get('content-length')) || 0, target);

--- a/tests/fetch.test.js
+++ b/tests/fetch.test.js
@@ -5,7 +5,7 @@ import https from 'node:https';
 import net from 'node:net';
 import tls from 'node:tls';
 
-const { fetchPage, followRedirects, resolveProxy, proxyGet } = await import('../src/fetch.js');
+const { fetchPage, followRedirects, resolveProxy, proxyGet, viaImpers } = await import('../src/fetch.js');
 
 const BLOCKED_MESSAGE = 'blocked: private or internal URL';
 
@@ -727,3 +727,73 @@ test('the proxy transport counts the body against the same cap', async () => {
     proxy.close();
   }
 });
+
+// A stand-in for the impers module whose get() either answers with a minimal
+// 200 page or refuses the identity the way impers does when the loaded native
+// library does not know the fingerprint an alias resolves to: it throws an
+// ImpersonateError before any request leaves the process (issue #40, where a
+// stale system libcurl-impersonate predating chrome150 broke oc outright).
+const fakeImpers = (refuse, html = '<html>ok</html>') => {
+  const identities = [];
+  const get = (url, opts) => {
+    identities.push(opts.impersonate);
+    if (refuse.includes(opts.impersonate)) {
+      const err = new Error(`Impersonating ${opts.impersonate} is not supported`);
+      err.name = 'ImpersonateError';
+      return Promise.reject(err);
+    }
+    return Promise.resolve({
+      status: 200,
+      headers: new Map([['content-type', 'text/html']]),
+      text: () => Promise.resolve(html),
+      url,
+    });
+  };
+  return { get, identities };
+};
+
+test('a refused chrome fingerprint falls back to the firefox identity', () => withoutProxyEnv(async () => {
+  const impers = fakeImpers(['chrome']);
+  const page = await viaImpers(impers, 'https://public.example/page');
+  assert.deepEqual(impers.identities, ['chrome', 'firefox']);
+  assert.equal(page.via, 'impers:firefox');
+  assert.equal(page.status, 200);
+  assert.equal(page.html, '<html>ok</html>');
+}));
+
+test('when both identities are refused the page still arrives via plain fetch', async () => {
+  // The proxy is only here to give viaFetch somewhere real to land without
+  // leaving the machine, same shape as the HTTP_PROXY wiring test above.
+  const seen = [];
+  const proxy = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.writeHead(200, { 'content-type': 'text/html' });
+    res.end('<html><title>via fetch</title></html>');
+  });
+  const port = await listen(proxy);
+  const prev = Object.fromEntries(PROXY_ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of PROXY_ENV_KEYS) delete process.env[k];
+  process.env.HTTP_PROXY = `http://127.0.0.1:${port}`;
+  try {
+    const impers = fakeImpers(['chrome', 'firefox']);
+    const page = await viaImpers(impers, 'http://1.1.1.1/page');
+    assert.deepEqual(impers.identities, ['chrome', 'firefox']);
+    assert.equal(page.via, 'fetch');
+    assert.equal(page.status, 200);
+    assert.equal(page.html, '<html><title>via fetch</title></html>');
+    assert.deepEqual(seen, ['http://1.1.1.1/page']);
+  } finally {
+    proxy.close();
+    for (const k of PROXY_ENV_KEYS) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k];
+    }
+  }
+});
+
+test('only an ImpersonateError downgrades; other impers failures propagate', () => withoutProxyEnv(async () => {
+  const impers = {
+    get: () => Promise.reject(new Error('connection reset')),
+  };
+  await assert.rejects(() => viaImpers(impers, 'https://public.example/page'), /connection reset/);
+}));


### PR DESCRIPTION
Fixes #40.

## What was happening

`oc open` died with `oc: Impersonating chrome150 is not supported` before any request left the machine. The chain:

1. `src/fetch.js` asks impers for the `chrome` identity with no handling around the call.
2. impers 0.1.1 resolves the `chrome` alias to `chrome150` and pins native curl-impersonate v2.1.1, which supports it. So a clean install works.
3. But impers prefers a system copy of libcurl-impersonate found at well-known paths (homebrew on macOS, `/usr/lib` on Linux) over its own pinned download. A system copy older than curl-impersonate v2.1.0 predates the `chrome150` target and refuses it with an `ImpersonateError`, which killed oc outright.

Reproduced both ways with impers 0.1.1: against its own downloaded v2.1.1 everything works; against a real v2.0.0 library (`LIBCURL_IMPERSONATE_PATH`) `oc open` fails with exactly the reported message, while `chrome146`, `chrome142`, and `firefox` all still work on that same library.

## The fix

An `ImpersonateError` now downgrades the same way a 403 already did: chrome falls back to firefox (an older target such libraries still know), and when both identities are refused the plain fetch transport gets the page. Any other impers failure propagates unchanged. No fingerprint is pinned, so installs where impers works correctly keep the newest chrome fingerprint.

Verified end to end: a fresh oc 0.5.0 install with impers 0.1.1 forced onto a v2.0.0 library fails on `main` and renders the page with this patch.

## Tests

Three new tests prove the downgrade chain against a fake impers: chrome refused falls back to firefox, both refused lands on plain fetch (through a local proxy, nothing leaves the machine), and a non-ImpersonateError failure still propagates.
