### PR TITLE
Drop fill and submit from the actions footer, they always throw

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -101,7 +101,6 @@ export function render(page, { budget = 500, from = 0 } = {}) {
   const lines = [...head];
   let spent = estimateTokens(lines.join('\n'));
   let hasLinks = false;
-  let hasInputs = false;
   let i = Math.max(0, from);
 
   // What the rest of the page would cost if it were all printed. When that is
@@ -129,7 +128,6 @@ export function render(page, { budget = 500, from = 0 } = {}) {
     spent += cost;
     lines.push(line);
     if (block.type === 'link' || block.type === 'button') hasLinks = true;
-    if (block.type === 'input') hasInputs = true;
   }
 
   const rest = blocks.slice(i);
@@ -140,10 +138,11 @@ export function render(page, { budget = 500, from = 0 } = {}) {
   if (rest.length) {
     lines.push(`... ${num(rest.length)} more blocks (~${num(leftTokens)} tokens): 'oc next' for the next ~${num(budget)}, 'oc raw' for all`);
   }
+  // An input on the page adds no action. 'fill' and 'submit' are still stubs
+  // that throw, and this footer is the line an agent trusts for what to run
+  // next, so naming one of them costs a turn and returns nothing.
   const actions = [
     hasLinks && 'do <n>',
-    hasInputs && 'fill <n> <text>',
-    hasInputs && 'submit',
     'read <n>',
     rest.length && 'next',
     'raw',

--- a/tests/act.test.js
+++ b/tests/act.test.js
@@ -244,3 +244,41 @@ test('a snippet stays one line even when the block it came from is code', () => 
   assert.match(lines[0], /^2 matches for "needle"/);
   assert.equal(lines[1], '[1] first(); needle(); third();');
 });
+
+test('no footer names a command that is not available yet', async () => {
+  // The footer is the line an agent reads to decide what to run next, so a
+  // name in it that always throws costs a turn and returns nothing. Which
+  // commands are stubs is probed here rather than listed, so the next stub to
+  // land is covered without anyone remembering to come back and add it.
+  const act = await import('../src/act.js');
+  const stubs = Object.entries(act)
+    .filter(([, value]) => typeof value === 'function')
+    .filter(([, fn]) => {
+      try {
+        fn();
+        return false;
+      } catch (err) {
+        return err instanceof act.NotImplemented;
+      }
+    })
+    .map(([name]) => name);
+  assert.ok(stubs.length, 'the probe found no stubs, so it is no longer testing anything');
+
+  open();
+  const loginHTML = readFileSync(new URL('./pages/login.html', import.meta.url), 'utf8');
+  // One output per place that builds a footer: a render with inputs, which is
+  // what used to offer fill and submit, and both of find's paths.
+  const outputs = [
+    render(page(), { budget: 500 }).text,
+    render(distill(loginHTML, 'https://example.test/login'), { budget: 500 }).text,
+    find('postgres'),
+    find('a'),
+  ];
+  const footers = outputs.flatMap((out) => out.split('\n').filter((line) => line.startsWith('actions:')));
+  assert.equal(footers.length, outputs.length, `every output should carry one footer:\n${footers.join('\n')}`);
+  for (const footer of footers) {
+    for (const stub of stubs) {
+      assert.ok(!footer.includes(stub), `footer offers '${stub}', which throws NotImplemented:\n${footer}`);
+    }
+  }
+});


### PR DESCRIPTION
Fixes #44.

## What this changes

`render.js` offered `fill <n> <text>` and `submit` in the `actions:` footer whenever the page had an input, but both are stubs that throw `NotImplemented`. The footer is the line an agent reads to pick its next command, so following it cost a turn and returned nothing.

Reproduced before the change on the two fixtures that have inputs:

```
news.html   actions: do <n> | fill <n> <text> | submit | read <n> | raw
login.html  actions: do <n> | fill <n> <text> | submit | read <n> | raw
```

## Token cost

The change only removes output, so it moves in the right direction:

```
news.html    before: 134 tokens    after: 127 tokens    delta: -7
login.html   before:  36 tokens    after:  30 tokens    delta: -6
```

## The test

`tests/act.test.js` gets one case asserting that no footer names a command that throws `NotImplemented`. It probes `act.js` for such handlers instead of listing them, so a future stub is covered the day it lands rather than the day someone remembers this test. It checks all three places that build a footer: `render.js`, and both of `find`'s paths.

Verified it fails without the fix:

```
not ok 25 - no footer names a command that is not available yet
    footer offers 'fill', which throws NotImplemented:
```

Full suite: 184 passing, offline, no new dependencies.

## Deliberately not included

Issue #44 also notes that `find` is implemented but appears in no footer. Adding it would grow every footer rather than shrink it, so it is a token call that deserves its own decision, and I left it out to keep this a pure fix. Happy to send it separately if you want it.

`back` and `session` are stubs too. Neither appears in a footer today, and the new test now keeps it that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
