### PR TITLE
feat: offer find in every actions footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ oc open news.ycombinator.com
 [1] Show HN: I built a tiny CSV toolkit
 [2] 312 comments
 ...
-actions: do <n> | read <n> | next | raw
+actions: do <n> | find <query> | read <n> | next | raw
 
 $ oc do 1
 ```

--- a/src/act.js
+++ b/src/act.js
@@ -234,7 +234,7 @@ export function find(query, { session = DEFAULT_SESSION, budget = 500 } = {}) {
     return [
       `1 match for "${query}"${separately}, region [${only.n}]`,
       read(only.n, { session, budget: budget * FINISH }),
-      `actions: ${follow}read <n> | next | raw`,
+      `actions: ${follow}find <query> | read <n> | next | raw`,
     ].join('\n');
   }
 
@@ -264,7 +264,9 @@ export function find(query, { session = DEFAULT_SESSION, budget = 500 } = {}) {
   if (shown < hits.length) {
     lines.push(`... ${hits.length - shown} more matches, narrow the query or raise --budget`);
   }
-  lines.push(`actions: ${[hasLinks && 'do <n>', 'read <n>', 'next', 'raw'].filter(Boolean).join(' | ')}`);
+  // Offering find on its own output is what makes "narrow the query" above an
+  // action rather than advice.
+  lines.push(`actions: ${[hasLinks && 'do <n>', 'find <query>', 'read <n>', 'next', 'raw'].filter(Boolean).join(' | ')}`);
   return lines.join('\n');
 }
 

--- a/src/render.js
+++ b/src/render.js
@@ -141,8 +141,15 @@ export function render(page, { budget = 500, from = 0 } = {}) {
   // An input on the page adds no action. 'fill' and 'submit' are still stubs
   // that throw, and this footer is the line an agent trusts for what to run
   // next, so naming one of them costs a turn and returns nothing.
+  //
+  // 'find' comes before 'read' because it is the cheaper way to go deeper: one
+  // command lands on the block that matters, where 'read' needs the right
+  // number first and 'next' pages toward it. The entry costs about three
+  // tokens on every render, and skipping one 'next' on a long page pays for
+  // a hundred of them.
   const actions = [
     hasLinks && 'do <n>',
+    'find <query>',
     'read <n>',
     rest.length && 'next',
     'raw',

--- a/tests/act.test.js
+++ b/tests/act.test.js
@@ -282,3 +282,23 @@ test('no footer names a command that is not available yet', async () => {
     }
   }
 });
+
+test('every footer offers find, the cheapest way to go deeper on a page', () => {
+  // SKILL.md lists find first under "going further, cheapest first", and the
+  // footer is what an agent actually reads, so the two have to agree. Same
+  // three footer sites as the stub probe above: a render, and both of find's
+  // paths.
+  open();
+  const outputs = [
+    render(page(), { budget: 500 }).text,
+    find('postgres'),
+    find('a'),
+  ];
+  const footers = outputs.map((out) => out.split('\n').find((line) => line.startsWith('actions:')));
+  assert.equal(footers.filter(Boolean).length, outputs.length, `every output should carry a footer:\n${footers.join('\n')}`);
+  for (const footer of footers) {
+    assert.ok(footer.includes('find <query>'), `footer should offer find:\n${footer}`);
+    // Cheapest first: find is listed ahead of read.
+    assert.ok(footer.indexOf('find <query>') < footer.indexOf('read <n>'), `find should come before read:\n${footer}`);
+  }
+});


### PR DESCRIPTION
Closes #46.

## What this changes

`find <query>` is implemented and dispatched but appeared in no `actions:` footer. The footer is the line an agent reads to pick its next command, so callers were steered toward `read`, `next`, and `raw` even though `skills/web-browsing-cli/SKILL.md` lists `find` first under "going further, cheapest first".

All three footers now offer it, after `do <n>` and before `read <n>` so the order matches the skill:

| Place | Footer |
|---|---|
| `src/render.js` | `actions: do <n> \| find <query> \| read <n> \| next \| raw` |
| `src/act.js`, find with one match | `actions: do <n> \| find <query> \| read <n> \| next \| raw` |
| `src/act.js`, find with several matches | `actions: do <n> \| find <query> \| read <n> \| next \| raw` |

On find's own output this turns the existing "narrow the query" hint into an action. The README example footer gains the entry too. `SKILL.md` needed no change.

## Token cost

Measured with `render` at the default budget on every HTML fixture in `tests/pages`:

| Fixture | Before | After | Delta |
|---|---|---|---|
| docs.html | 120 | 123 | +3 |
| forum.html | 695 | 699 | +4 |
| login.html | 30 | 33 | +3 |
| news.html | 127 | 131 | +4 |
| search.html | 94 | 97 | +3 |
| social.html | 418 | 422 | +4 |
| youtube_watch.html | 80 | 84 | +4 |

A single `next` at the default budget is about 500 tokens, so one skipped page pays for over a hundred renders carrying the entry.

## Test

`tests/act.test.js` gets a sibling of the stub probe from #45, checking the same three footer sites: `find <query>` is present in each and listed ahead of `read <n>`. Verified it fails on main:

```
not ok 26 - every footer offers find, the cheapest way to go deeper on a page
```

Full suite: 188 passing, offline, no new dependencies.
