### PR TITLE
release: 0.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "only-cli",
       "source": { "source": "github", "repo": "only-cli/oc" },
       "description": "Browse websites from the terminal in a few hundred tokens",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "homepage": "https://github.com/only-cli/oc",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "only-cli",
   "description": "Browse websites from the terminal in a few hundred tokens",
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes per release. Releases before 0.4.0 are listed at
 [github.com/only-cli/oc/releases](https://github.com/only-cli/oc/releases).
 
-## Unreleased
+## 0.5.2
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@only-cli/oc",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "impers": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Turn websites into a compact CLI so AI agents can browse without burning tokens.",
   "type": "module",
   "bin": {

--- a/skills/web-browsing-cli/SKILL.md
+++ b/skills/web-browsing-cli/SKILL.md
@@ -8,15 +8,15 @@ description: Token-efficient web browsing and web content extraction for AI agen
 Renders a web page as a compact, numbered terminal view instead of raw HTML. A typical page is under 500 tokens.
 
 ```
-npx --yes @only-cli/oc@0.5.1 open <url>     compact view, numbered elements
-npx --yes @only-cli/oc@0.5.1 do <n>         follow link [n], or read it if [n] is text
-npx --yes @only-cli/oc@0.5.1 find <query>   where a string appears, or that place itself
+npx --yes @only-cli/oc@0.5.2 open <url>     compact view, numbered elements
+npx --yes @only-cli/oc@0.5.2 do <n>         follow link [n], or read it if [n] is text
+npx --yes @only-cli/oc@0.5.2 find <query>   where a string appears, or that place itself
                                             when only one matches
-npx --yes @only-cli/oc@0.5.1 next           next ~500 tokens of the page already open
-npx --yes @only-cli/oc@0.5.1 read <n>       full text of region [n]
-npx --yes @only-cli/oc@0.5.1 raw [url]      whole page as markdown (--html for cleaned HTML)
-npx --yes @only-cli/oc@0.5.1 login            seed cookies (--cookie, --domain, --expires)
-npx --yes @only-cli/oc@0.5.1 logout [session] forget a session: cookies and saved page
+npx --yes @only-cli/oc@0.5.2 next           next ~500 tokens of the page already open
+npx --yes @only-cli/oc@0.5.2 read <n>       full text of region [n]
+npx --yes @only-cli/oc@0.5.2 raw [url]      whole page as markdown (--html for cleaned HTML)
+npx --yes @only-cli/oc@0.5.2 login            seed cookies (--cookie, --domain, --expires)
+npx --yes @only-cli/oc@0.5.2 logout [session] forget a session: cookies and saved page
 ```
 
 None of these except `open`/`do`/`raw <url>` fetch anything; they replay the page `open` already saved.


### PR DESCRIPTION
Cuts 0.5.2 with the Reddit fix merged in #53.

## Version

0.5.2 in `package.json`, the lockfile, `.claude-plugin/plugin.json`, the marketplace entry, and the `npx --yes @only-cli/oc@...` pins inside the skill.

## CHANGELOG

Covers 0.5.2 against 0.5.1:

- #52 `oc reddit` reads the Atom feeds on www.reddit.com. old.reddit.com has sent logged-out readers to a login page since 30 June 2026, and the www `.json` views answer 403 without an OAuth token whatever the fingerprint. `sub`, `post`, `user`, and `search` point at the feeds, `new <name>` and `top <name>` are added, and the entry states the two limits: no scores or comment counts, and about ten anonymous requests a minute per address.

## Docs

The README Reddit row was updated inside #53. The README Benchmarks section still says "oc 0.5.1, September 2026", which is the run those numbers came from; a rerun against the published 0.5.2 is a follow-up in only-cli/benchmarks once it is on npm, and the Reddit rows there will change from an honest login-wall report to real content.

## Checks

`npm test` passes 215/215 across six runs. One earlier run had a single failure that did not repeat, so its name was not captured. The skill pin check that the publish workflow enforces on stable releases resolves to `@only-cli/oc@0.5.2` only.
