### PR TITLE
release: 0.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
       "name": "only-cli",
       "source": { "source": "github", "repo": "only-cli/oc" },
       "description": "Browse websites from the terminal in a few hundred tokens",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "homepage": "https://github.com/only-cli/oc",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "only-cli",
   "description": "Browse websites from the terminal in a few hundred tokens",
-  "version": "0.5.2"
+  "version": "0.5.3"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes per release. Releases before 0.4.0 are listed at
 [github.com/only-cli/oc/releases](https://github.com/only-cli/oc/releases).
 
-## Unreleased
+## 0.5.3
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@only-cli/oc",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "impers": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@only-cli/oc",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Turn websites into a compact CLI so AI agents can browse without burning tokens.",
   "type": "module",
   "bin": {

--- a/skills/web-browsing-cli/SKILL.md
+++ b/skills/web-browsing-cli/SKILL.md
@@ -8,15 +8,15 @@ description: Token-efficient web browsing and web content extraction for AI agen
 Renders a web page as a compact, numbered terminal view instead of raw HTML. A typical page is under 500 tokens.
 
 ```
-npx --yes @only-cli/oc@0.5.2 open <url>     compact view, numbered elements
-npx --yes @only-cli/oc@0.5.2 do <n>         follow link [n], or read it if [n] is text
-npx --yes @only-cli/oc@0.5.2 find <query>   where a string appears, or that place itself
+npx --yes @only-cli/oc@0.5.3 open <url>     compact view, numbered elements
+npx --yes @only-cli/oc@0.5.3 do <n>         follow link [n], or read it if [n] is text
+npx --yes @only-cli/oc@0.5.3 find <query>   where a string appears, or that place itself
                                             when only one matches
-npx --yes @only-cli/oc@0.5.2 next           next ~500 tokens of the page already open
-npx --yes @only-cli/oc@0.5.2 read <n>       full text of region [n]
-npx --yes @only-cli/oc@0.5.2 raw [url]      whole page as markdown (--html for cleaned HTML)
-npx --yes @only-cli/oc@0.5.2 login            seed cookies (--cookie, --domain, --expires)
-npx --yes @only-cli/oc@0.5.2 logout [session] forget a session: cookies and saved page
+npx --yes @only-cli/oc@0.5.3 next           next ~500 tokens of the page already open
+npx --yes @only-cli/oc@0.5.3 read <n>       full text of region [n]
+npx --yes @only-cli/oc@0.5.3 raw [url]      whole page as markdown (--html for cleaned HTML)
+npx --yes @only-cli/oc@0.5.3 login            seed cookies (--cookie, --domain, --expires)
+npx --yes @only-cli/oc@0.5.3 logout [session] forget a session: cookies and saved page
 ```
 
 None of these except `open`/`do`/`raw <url>` fetch anything; they replay the page `open` already saved.


### PR DESCRIPTION
Version pins to 0.5.3 in package.json, package-lock.json, the plugin manifests, and the skill's npx lines. The CHANGELOG Unreleased section becomes 0.5.3.

What ships: #56, reddit.com asked with the firefox fingerprint first. `npm test`: 217 passing.